### PR TITLE
Workaround failing TwineAuthenticate to publish to PyPi

### DIFF
--- a/.pypirc
+++ b/.pypirc
@@ -1,0 +1,12 @@
+[distutils]
+index-servers =
+    pypi
+    testpypi
+
+[pypi]
+username = __token__
+password = __pypiToken__
+
+[testpypi]
+username = __token__
+password = __pypiTestToken__


### PR DESCRIPTION
Just use a local .pypric file with variable token value to upload to PyPi because the Azure Devops TwineAuthenticate@1 is unable to get the username during the twine upload.