### PR TITLE
Fix a broken url in the README.md. Add code to replace README.md urls for publish.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ print('Connected to Safeguard as %s' % me.json()['DisplayName'])
 ```
 
 Password authentication to an external provider is as follows:
-(Sample can be found <a href="samples/externalprovider.py">here</a>.)
+(Sample can be found <a href="samples\PasswordExternalExample.py">here</a>.)
 
 ```Python
 from pysafeguard import *

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,24 @@ stages:
         displayName: Update pyproject.toml to $(build.SourceBranchName)
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
+      - task: PowerShell@2
+        displayName: Update README.md with absolute paths
+        inputs:
+          targetType: 'inline'
+          script: |
+            # The README.md gets published and is what folks see on the PyPi/project/pysafeguard so the relative paths
+            # must be updated to absolute paths.
+            
+            $file = "README.md"
+            (Get-Content $file).replace('<a href="samples">sample projects</a>', "[sample projects](https://github.com/OneIdentity/PySafeguard/tree/release/$Env:BUILD_SOURCEBRANCHNAME/samples)") | Set-Content $file
+            (Get-Content $file).replace('<a href="samples\PasswordExternalExample.py">here</a>', "[here](https://github.com/OneIdentity/PySafeguard/tree/release/$Env:BUILD_SOURCEBRANCHNAME/samples/PasswordExternalExample.py)") | Set-Content $file
+            (Get-Content $file).replace('<a href="samples\PasswordExample.py">here</a>', "[here](https://github.com/OneIdentity/PySafeguard/tree/release/$Env:BUILD_SOURCEBRANCHNAME/samples/PasswordExample.py)") | Set-Content $file
+            (Get-Content $file).replace('<a href="samples\AnonymousExample.py">here</a>', "[here](https://github.com/OneIdentity/PySafeguard/tree/release/$Env:BUILD_SOURCEBRANCHNAME/samples/AnonymousExample.py)") | Set-Content $file
+            (Get-Content $file).replace('<a href="samples\SignalRExample.py">here</a>', "[here](https://github.com/OneIdentity/PySafeguard/tree/release/$Env:BUILD_SOURCEBRANCHNAME/samples/SignalRExample.py)") | Set-Content $file
+            (Get-Content $file).replace('<a href="samples\NewUserExample.py">here</a>', "[here](https://github.com/OneIdentity/PySafeguard/tree/release/$Env:BUILD_SOURCEBRANCHNAME/samples/NewUserExample.py)") | Set-Content $file
+          failOnStderr: true
+          condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+          
       - script: |
          poetry build
         displayName: Build PyPi dist


### PR DESCRIPTION
Note, the task to update the urls in the readme has no condition at this time so I can test before we publish to release.

@RichGagliano Ok that seems to have worked. I went through multiple commits to trigger the pipeline and test the result. The artifact on the last run before I removed the commit has the readme correct. In this case, I did not have the condition on the Powershell@2 to replace urls so I could test. I fixed "blob" to be "tree" since that is where that url will redirect. Also, for the test, when the PR goes up the $Env:BUILD_SOURCEBRANCHNAME = "merge" so the URLS are 

![image](https://user-images.githubusercontent.com/22480188/193731609-39ece10d-75ba-473f-ad50-9676cead07a0.png)