### PR TITLE
chore: add .worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Worktrees
+.worktrees/


### PR DESCRIPTION
Add `.worktrees/` directory to `.gitignore` to support git worktree-based development workflows.

This prevents worktree directories from being accidentally committed to the repository.