### PR TITLE
chore: modernize pipeline for tag-based releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require review from SafeguardPasswords team for all changes
+* @OneIdentity/SafeguardPasswords
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,11 +8,13 @@ trigger:
     - release-*
   tags:
     include:
-    - '*'
+    - 'v*'
   paths:
     exclude:
-    - README.md
-    - AGENTS.md
+    - '**/*.md'
+    - LICENSE
+    - docs/
+    - .github/CODEOWNERS
 
 pr:
   branches:
@@ -21,8 +23,10 @@ pr:
     - release-*
   paths:
     exclude:
-    - README.md
-    - AGENTS.md
+    - '**/*.md'
+    - LICENSE
+    - docs/
+    - .github/CODEOWNERS
 
 jobs:
 # Job 1: PR Validation - runs only on pull requests
@@ -56,7 +60,7 @@ jobs:
       action: 'create'
       target: '$(Build.SourceVersion)'
       tagSource: 'userSpecifiedTag'
-      tag: '$(PackageVersion)'
+      tag: '$(ReleaseTag)'
       title: '$(PackageVersion)'
       releaseNotesSource: 'inline'
       releaseNotesInline: ''

--- a/versionnumber.ps1
+++ b/versionnumber.ps1
@@ -18,8 +18,14 @@ Write-Host "TagName = $TagName"
 Write-Host "IsTagBuild = $($local:IsTagBuildBool)"
 
 if ($local:IsTagBuildBool) {
-    # Tag builds use the tag name as the version (e.g. tag "8.0.0" -> version "8.0.0")
-    $local:PackageVersion = $TagName
+    # Validate tag format: must be v<major>.<minor>.<patch> with optional pre-release suffix
+    if ($TagName -notmatch '^v\d+\.\d+\.\d+') {
+        Write-Error "Tag '$TagName' does not match expected format 'v<major>.<minor>.<patch>'. Aborting release build."
+        exit 1
+    }
+    # Tag builds use the tag name as the version, stripping the 'v' prefix
+    # e.g. tag "v8.1.0" -> version "8.1.0"
+    $local:PackageVersion = $TagName -replace '^v', ''
     Write-Host "Tag build detected, using tag name as version"
 }
 else {
@@ -33,4 +39,14 @@ Write-Host "PackageVersion = $($local:PackageVersion)"
 
 poetry version $local:PackageVersion
 
+# Compute release tag: tag builds reuse the trigger tag; dev builds use non-triggering prefix
+if ($local:IsTagBuildBool) {
+    $local:ReleaseTag = $TagName
+} else {
+    $local:ReleaseTag = "dev/v${local:PackageVersion}"
+}
+
+Write-Host "ReleaseTag = $($local:ReleaseTag)"
+
 Write-Output "##vso[task.setvariable variable=PackageVersion;]$($local:PackageVersion)"
+Write-Output "##vso[task.setvariable variable=ReleaseTag;]$($local:ReleaseTag)"


### PR DESCRIPTION
## Changes

- **Tag trigger**: `'*'` to `'v*'` - only trigger on v-prefixed semver tags
- **versionnumber.ps1**: Strip `v` prefix from tag name for valid PEP 440 versions (e.g. tag `v8.1.0` becomes version `8.1.0`)
- **Tag format validation**: Fails fast if tag doesn't match `v<major>.<minor>.<patch>` pattern
- **ReleaseTag variable**: Tag builds reuse the trigger tag; dev builds use `dev/v<version>` prefix to avoid re-triggering the pipeline
- **Path exclusions**: Broadened from `README.md`/`AGENTS.md` to `**/*.md`, `LICENSE`, `docs/`, `.github/CODEOWNERS`
- **GitHubRelease**: Tag changed from PackageVersion to ReleaseTag - tag builds reuse the trigger tag, dev builds use dev/ prefix
- **CODEOWNERS**: Added requiring SafeguardPasswords team review

Branch triggers (`main`, `release-*`) are preserved as-is.