### PR TITLE
Fix GitHub Release title to use ReleaseTag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
       target: '$(Build.SourceVersion)'
       tagSource: 'userSpecifiedTag'
       tag: '$(ReleaseTag)'
-      title: '$(PackageVersion)'
+      title: '$(ReleaseTag)'
       releaseNotesSource: 'inline'
       releaseNotesInline: ''
       isPreRelease: ${{ not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}


### PR DESCRIPTION
One-line fix: change GitHub Release title from PackageVersion to ReleaseTag so the title matches the tag name, consistent with all other Safeguard repos.