### PR TITLE
Skills harmonization: add build-and-release and a2a-workflow skills

### DIFF
--- a/.agents/skills/a2a-workflow/SKILL.md
+++ b/.agents/skills/a2a-workflow/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: a2a-workflow
+description: Use when setting up or troubleshooting Safeguard A2A certificate registrations, API keys, credential retrieval, brokering, or A2A-backed event listeners.
+---
+
+# A2A workflow
+
+## 1. What A2A is
+
+PySafeguard's A2A support is centered on `A2AContext` and `AsyncA2AContext`, thin wrappers over Safeguard's Application-to-Application APIs. The normal A2A credential calls (`retrieve_password`, `set_password`, `retrieve_private_key`, `set_private_key`, `retrieve_api_key_secret`) do **not** use a user bearer token. Instead, each request combines a trusted client certificate on the TLS connection with an `Authorization: A2A <api_key>` header that identifies the specific retrievable account registration. The one exception is `get_retrievable_accounts()`, which lazily logs in with `CertificateAuth` and queries Core API registration data.
+
+### Relevant SDK surface
+
+| Item | Location | Notes |
+|---|---|---|
+| `A2AContext` | `src/pysafeguard/a2a.py` | Sync A2A helper built on `SafeguardClient` |
+| `AsyncA2AContext` | `src/pysafeguard/async_a2a.py` | Async mirror built on `AsyncSafeguardClient` |
+| `A2AType` | `src/pysafeguard/data_types.py` | `PASSWORD`, `PRIVATEKEY`, `APIKEYSECRET` |
+| `SshKeyFormat` | `src/pysafeguard/data_types.py` | `OPENSSH`, `SSH2`, `PUTTY` |
+| `HiddenString` | `src/pysafeguard/hidden_string.py` | Returned for passwords/private keys |
+| `SafeguardEventListener` | `src/pysafeguard/event.py` | Used for A2A-backed SignalR listeners |
+
+### Supported A2A credential types
+
+| Enum value | Meaning | Primary method |
+|---|---|---|
+| `A2AType.PASSWORD` | Managed password retrieval | `retrieve_password()` / `set_password()` |
+| `A2AType.PRIVATEKEY` | SSH private key retrieval | `retrieve_private_key()` / `set_private_key()` |
+| `A2AType.APIKEYSECRET` | API key secret retrieval | `retrieve_api_key_secret()` |
+
+## 2. Setup flow
+
+The repository's most concrete A2A setup reference is `tests/integration/test_a2a.py`. That fixture builds a complete appliance-side A2A environment and is the best source of truth for how the SDK expects the feature to be provisioned.
+
+### Appliance-side setup sequence
+
+1. Acquire or generate a PEM client certificate and matching private key
+2. Upload the certificate to `Service.CORE`, endpoint `TrustedCertificates`
+3. Create a certificate-backed user whose `PrimaryAuthenticationProvider` is certificate auth (`Id: -2`) and whose `Identity` is the cert thumbprint
+4. Create or identify the asset account that should be retrievable
+5. Create an A2A registration with `POST Service.CORE, "A2ARegistrations"`
+6. Set `CertificateUserId` on that registration
+7. If write-back is required, enable `BidirectionalEnabled` on the registration before calling `set_password()` or `set_private_key()`
+8. Add retrievable accounts with `POST A2ARegistrations/{reg_id}/RetrievableAccounts`
+9. Persist the returned `ApiKey` securely; that value becomes the `api_key` argument passed to SDK methods
+
+### What the integration tests actually provision
+
+`tests/integration/test_a2a.py` creates:
+
+- a trusted self-signed client certificate
+- a certificate user linked to the uploaded cert thumbprint
+- an `Other Managed` asset
+- a password-managed account
+- a second account with an SSH key
+- an A2A registration with both password and private-key retrievable accounts
+- `BidirectionalEnabled = True` so mutation APIs can be exercised
+
+That makes the tests a good recipe when you need a disposable appliance setup for real validation.
+
+### Minimal sync usage
+
+```python
+from pysafeguard import A2AContext
+
+with A2AContext(host, cert_file, key_file, verify=ca_file) as ctx:
+    password = ctx.retrieve_password(api_key)
+    print(password.value)
+```
+
+### Minimal async usage
+
+```python
+from pysafeguard import AsyncA2AContext
+
+async with AsyncA2AContext(host, cert_file, key_file, verify=ca_file) as ctx:
+    password = await ctx.retrieve_password(api_key)
+    print(password.value)
+```
+
+### Constructor rules
+
+Both context classes enforce certificate input up front:
+
+- `cert_file` is required
+- `key_file` is required
+- missing either raises `ValueError("cert_file and key_file are required for A2A context")`
+
+`verify` accepts the same forms as the main client classes:
+
+- `True` - use system trust
+- `False` - disable TLS verification
+- `str` - CA bundle path
+
+## 3. Credential retrieval
+
+### Core methods
+
+| Method | Returns | Notes |
+|---|---|---|
+| `retrieve_password(api_key)` | `HiddenString` | GET `Service.A2A/Credentials?type=password` |
+| `set_password(api_key, password)` | `None` | PUT `Credentials/Password` with JSON body |
+| `retrieve_private_key(api_key, key_format=...)` | `HiddenString` | Adds `key_format` query param for private-key retrieval |
+| `set_private_key(api_key, private_key, passphrase="", key_format=...)` | `None` | PUT `Credentials/SshKey` with `PrivateKey` and `Passphrase` |
+| `retrieve_api_key_secret(api_key)` | `JsonType` | Raw JSON result, not `HiddenString` |
+| `get_retrievable_accounts(filter=None)` | `list[dict[str, JsonType]]` | Uses Core API, not direct A2A auth |
+
+### One-shot helpers
+
+`A2AContext` includes convenience helpers when you do not want to keep a context open:
+
+- `A2AContext.quick_retrieve_password(...)`
+- `A2AContext.quick_retrieve_private_key(...)`
+- `AsyncA2AContext.quick_retrieve_password(...)`
+- `AsyncA2AContext.quick_retrieve_private_key(...)`
+
+There is **no** quick helper for API key secret retrieval today; create a context and call `retrieve_api_key_secret()` directly.
+
+### HiddenString handling
+
+Passwords and private keys are wrapped in `HiddenString`.
+
+- prefer `.value` to access plaintext
+- `.get_value()` still works, but is deprecated in favor of `.value`
+- `print(secret)` shows `***`
+- `repr(secret)` shows `HiddenString(***)`
+- `dispose()` zeroes the internal bytearray buffer
+- the object also works as a context manager for scoped secret use
+
+Example:
+
+```python
+with A2AContext(host, cert_file, key_file, verify=ca_file) as ctx:
+    with ctx.retrieve_password(api_key) as password:
+        use_password(password.value)
+```
+
+### Retrievable account discovery
+
+`get_retrievable_accounts()` is special:
+
+- it lazily sets `self._conn._auth = CertificateAuth(...)`
+- it calls `login()` to obtain a user token
+- it lists `A2ARegistrations`
+- it queries each registration's `RetrievableAccounts`
+- it decorates each account with registration metadata:
+  - `ApplicationName`
+  - `Description`
+  - `Disabled`
+
+Use this when you need inventory/discovery behavior, not when you already have an API key.
+
+## 4. Brokering
+
+A2A brokering is supported in both sync and async contexts.
+
+### API surface
+
+- `A2AContext.broker_access_request(api_key, access_request)`
+- `AsyncA2AContext.broker_access_request(api_key, access_request)`
+
+### How it works
+
+The SDK sends:
+
+- `POST Service.A2A, "AccessRequests"`
+- JSON body = the `access_request` dict you provide
+- headers include `Authorization: A2A <api_key>`
+- client cert tuple is passed through the request
+
+On success, the method returns the created access request identifier as `str`.
+
+### Important limitation
+
+The SDK does **not** define a higher-level request model for brokering. You must construct the `access_request` payload yourself to match the Safeguard appliance API you are targeting. There is also no sample script or integration test for brokering in this repository, so validate the payload against a live appliance before depending on it.
+
+## 5. Event listeners / SignalR
+
+A2A contexts can produce SignalR listeners even though the listener implementation itself lives in `event.py`.
+
+### Listener factory methods
+
+| Method | Returns | Notes |
+|---|---|---|
+| `get_event_listener(api_key)` | `SafeguardEventListener` | Uses the A2A API key as the SignalR access token |
+| `get_persistent_event_listener(api_key)` | `PersistentSafeguardEventListener` | Reconnects with `token_factory=lambda: api_key` |
+
+### Async behavior
+
+`AsyncA2AContext.get_event_listener()` and `.get_persistent_event_listener()` are still **synchronous** methods that return the same thread-based listener classes used by the sync API. The integration tests explicitly verify this behavior.
+
+### SignalR prerequisites
+
+- install the `signalr` extra: `pip install pysafeguard[signalr]`
+- listener connects to `Service.EVENT/signalr`
+- if `verify` is a CA path, `event.py` builds an `ssl.SSLContext` for `signalrcore`
+- if `verify` is `False`, the listener disables WebSocket TLS verification
+
+### A2A-specific event handling quirk
+
+`EventHandlerRegistry.handle_event()` has an A2A workaround: if the incoming event `Name` is numeric, it extracts the real event name from `Data.EventName`. Preserve that behavior when changing listener code; it matches the SafeguardDotNet behavior expected by the appliance.
+
+### General listener usage pattern
+
+The sample files `samples/SignalRExample.py` and `samples/PersistentSignalRExample.py` show the standard listener lifecycle:
+
+- call `.on("EventName", handler)` to register handlers
+- optionally call `.on_state_change(callback)`
+- call `.start()`
+- call `.stop()` or leave the context manager
+
+A2A listeners use the same API; the only difference is that you obtain them from `A2AContext` with an API key instead of from an authenticated `SafeguardClient`.
+
+## 6. Error scenarios and troubleshooting
+
+### Common configuration failures
+
+- Missing `cert_file` or `key_file` -> `ValueError`
+- Empty `api_key` -> `ValueError("api_key must not be empty")`
+- Untrusted or mismatched certificate -> request/login failures from the appliance
+- Cert user or registration not configured -> A2A or Core API authorization failures
+
+### Authentication and authorization failures
+
+Integration tests show that an invalid API key raises `AuthorizationError` with status code `403` for both sync and async retrieval methods.
+
+If the error comes from `get_retrievable_accounts()`, remember that the failing path is certificate-backed user login against the Core API, not direct `Authorization: A2A ...` credential retrieval.
+
+### Content-type gotcha for password updates
+
+`set_password()` uses `json=` internally. If you bypass the helper and call the endpoint yourself with `data=`, Safeguard returns `415 Unsupported Media Type`. Use the SDK helper or send JSON manually.
+
+### Extras and import failures
+
+- `AsyncA2AContext` depends on the `async` extra (`aiohttp`)
+- SignalR listeners depend on the `signalr` extra (`signalrcore`)
+- `event.py` raises a helpful `SafeguardError` when `signalrcore` is missing
+
+### SignalR handshake issue
+
+`signalrcore` 1.0.2 has a protocol-version bug. PySafeguard works around it by forcing `JsonHubProtocol(version=1)`. If A2A event listeners suddenly start failing after listener refactors, verify that `_json_hub_protocol()` still forces version `1`.
+
+### TLS troubleshooting
+
+Use a CA bundle path instead of `verify=False` whenever possible.
+
+Helpful environment variables for appliance environments that use an internal CA:
+
+- `REQUESTS_CA_BUNDLE` for HTTP requests
+- `WEBSOCKET_CLIENT_CA_BUNDLE` for SignalR/WebSocket traffic
+
+### Safe debugging rules
+
+- never print or log `password.value` or private-key plaintext in committed samples/tests
+- prefer inspecting `HiddenString` redacted behavior unless plaintext is strictly required
+- dispose transient secrets promptly when writing new helpers
+- do not commit client certs, private keys, A2A API keys, or captured access-request payloads

--- a/.agents/skills/build-and-release/SKILL.md
+++ b/.agents/skills/build-and-release/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: build-and-release
+description: Use when changing Azure Pipelines, reproducing CI locally, or validating PySafeguard version stamping and publishing.
+---
+
+# Build and release
+
+Use this skill when you need to change `azure-pipelines.yml`, debug why a build or release ran, reproduce the pipeline locally, or understand how PySafeguard versions are stamped and published.
+
+## 1. Pipeline architecture
+
+### Files involved
+
+| File | Role |
+|---|---|
+| `azure-pipelines.yml` | Top-level pipeline definition: triggers, job conditions, GitHub release, and PyPI publish steps |
+| `pipeline-templates/global-variables.yml` | Computes `isTagBuild` from `Build.SourceBranch` |
+| `pipeline-templates/build-steps.yml` | Shared install/lint/test/build/twine-check steps used by both jobs |
+| `versionnumber.ps1` | Converts the base semantic version into the build/package version and release tag |
+| `pyproject.toml` | Poetry metadata, base semantic version, package name, dependencies, and pytest config |
+
+### Trigger model
+
+The pipeline is intentionally narrow:
+
+- Push CI runs on `main` and `release-*`
+- Tag builds run on tags matching `v*`
+- PR validation runs for pull requests targeting `main` and `release-*`
+- Docs-only changes are excluded from CI and PR runs:
+  - `**/*.md`
+  - `LICENSE`
+  - `docs/`
+  - `.github/CODEOWNERS`
+
+### Job layout
+
+There are no explicit Azure DevOps stages; the pipeline uses two jobs with mutually exclusive conditions:
+
+1. `PRValidation`
+   - Runs only when `Build.Reason == PullRequest`
+   - Uses `ubuntu-latest`
+   - Imports `pipeline-templates/build-steps.yml`
+   - Validates install, version stamping, linting, typing, unit tests, packaging, and `twine check`
+
+2. `BuildAndPublish`
+   - Runs for non-PR builds
+   - Uses the same shared build template
+   - Always creates a GitHub release for merge/tag builds
+   - Uploads to PyPI only when the build was triggered from a tag
+
+### Shared build sequence
+
+Both jobs run the same steps from `pipeline-templates/build-steps.yml`:
+
+1. Select Python `3.12` with `UsePythonVersion@0`
+2. Upgrade `pip` and `wheel`
+3. Install Poetry
+4. Run `poetry install --all-extras`
+5. Execute `versionnumber.ps1`
+6. Run `poetry run ruff check src/`
+7. Run `poetry run ruff format --check src/`
+8. Run `poetry run mypy src/`
+9. Run unit tests only: `poetry run python -m pytest tests/ -m "not integration" --tb=short -q`
+10. Build the wheel and sdist with `poetry build`
+11. Install Twine and validate the package with `twine check dist/*`
+12. Copy `dist/*` into the artifact staging directory
+13. Publish the staged files as Azure Pipeline artifact `drop`
+
+The artifact publishing steps are guarded with `succeededOrFailed()`, so failed builds still expose `dist/*` when those files exist.
+
+### Release-specific steps
+
+`BuildAndPublish` adds two publishing paths after the shared build:
+
+- **GitHub release** via `GitHubRelease@1`
+  - Service connection: `PangaeaBuild-GitHub`
+  - Repository: `OneIdentity/PySafeguard`
+  - Assets: `$(Build.ArtifactStagingDirectory)/dist/*`
+  - Changelog: `commitBased`, compared to `lastFullRelease`
+  - `isPreRelease` is `true` for non-tag builds
+
+- **PyPI publish** via Twine
+  - Runs only when `Build.SourceBranch` starts with `refs/tags/`
+  - Installs Twine, authenticates with `TwineAuthenticate@1`, then uploads `dist/*`
+
+## 2. Version strategy
+
+### Single source of truth
+
+The base semantic version lives in `pyproject.toml` under `[project].version`.
+
+`versionnumber.ps1` reads it with:
+
+```powershell
+poetry version --short
+```
+
+That means the checked-in value is the release baseline, not necessarily the exact artifact version produced in CI.
+
+### Tag builds
+
+Tag builds are release builds.
+
+- `isTagBuild` comes from `startsWith(Build.SourceBranch, 'refs/tags/')`
+- `versionnumber.ps1` validates the tag with `^v\d+\.\d+\.\d+`
+- The package version is the tag with the leading `v` removed
+  - `v8.1.0` -> `8.1.0`
+- `ReleaseTag` is the original tag name
+
+The regex only validates the `v<major>.<minor>.<patch>` prefix, so tags with an allowed suffix after that prefix still pass.
+
+### Non-tag builds
+
+Branch builds become development packages.
+
+- `PackageVersion = <semantic-version>.dev<BuildId % 65534>`
+- Example: base `8.0.2` and build id `70001` becomes `8.0.2.dev4467`
+- `ReleaseTag = dev/v<PackageVersion>`
+
+The modulo keeps the dev suffix inside the range accepted by Python packaging tools.
+
+### Important implications
+
+- CI mutates the version in-place with `poetry version <PackageVersion>`
+- Do not manually edit the checked-in version just to mimic a CI dev build
+- If you run `versionnumber.ps1` locally, expect `pyproject.toml` to change until you reset it
+- Real releases are created by pushing a `v*` tag, not by editing files in the build output
+
+## 3. Build commands
+
+### Local CI reproduction
+
+Run these from the repo root:
+
+```bash
+pip install poetry
+poetry install --all-extras
+poetry run ruff check src/
+poetry run ruff format --check src/
+poetry run mypy src/
+poetry run python -m pytest tests/ -m "not integration" --tb=short -q
+poetry build
+pip install twine
+twine check dist/*
+```
+
+### Matching the pipeline environment
+
+- Prefer Python `3.12` locally when reproducing CI because the pipeline pins that interpreter
+- `poetry install --all-extras` is important because the repo's checks depend on dev tools and optional extras being available
+- CI does **not** run integration tests; those remain a separate live-appliance workflow
+
+### Simulating version stamping locally
+
+Use PowerShell from the repo root:
+
+```powershell
+pwsh .\versionnumber.ps1 -BuildId 12345 -TagName v8.0.2 -IsTagBuild $true
+pwsh .\versionnumber.ps1 -BuildId 12345 -TagName main -IsTagBuild $false
+```
+
+After a dry run, revert `pyproject.toml` unless you intentionally changed the base semantic version.
+
+## 4. Publishing targets
+
+### Registries and release destinations
+
+| Target | When it runs | What is published |
+|---|---|---|
+| Azure Pipeline artifact `drop` | Every build, even on failure when artifacts exist | `dist/*` |
+| GitHub Releases | Every non-PR build | `dist/*` plus generated changelog |
+| PyPI | Tagged builds only | `dist/*` via Twine |
+
+### Pre-release behavior
+
+- Branch builds publish GitHub prereleases tagged `dev/v<PackageVersion>`
+- Tag builds publish full GitHub releases and push the same package version to PyPI
+
+### Signing
+
+There is currently **no package signing step** in the pipeline.
+
+- No GPG signing
+- No Sigstore step
+- No trusted publishing exchange beyond the configured Twine service connection
+
+If signing is added later, update this skill and `AGENTS.md` in the same change.
+
+## 5. Service connections / secrets required
+
+### Azure DevOps connections and injected variables
+
+- `PangaeaBuild-GitHub` - required by `GitHubRelease@1`
+- `pypiOneIdentity` - required by `TwineAuthenticate@1`
+- `$(PYPIRC_PATH)` - generated by Twine authentication and consumed by `twine upload`
+- Build variables used by the versioning flow:
+  - `Build.SourceBranch`
+  - `Build.SourceBranchName`
+  - `Build.SourceVersion`
+  - `Build.BuildId`
+
+### Secret handling rules
+
+- Do not commit `.pypirc`, PyPI tokens, GitHub tokens, or exported service-connection credentials
+- Do not hardcode release credentials into scripts or `pyproject.toml`
+- Keep release automation inside Azure DevOps service connections whenever possible
+
+### Safe release checklist
+
+1. Update the base semantic version in `pyproject.toml` only when intentionally changing the SDK version line
+2. Validate the shared build steps locally before pushing release changes
+3. Push to `main` or `release-*` to verify dev build behavior
+4. Push a `vX.Y.Z` tag to trigger the real PyPI publish path
+5. When pipeline behavior changes, review all of:
+   - `azure-pipelines.yml`
+   - `pipeline-templates/build-steps.yml`
+   - `pipeline-templates/global-variables.yml`
+   - `versionnumber.ps1`
+   - `AGENTS.md`
+   - this skill

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,162 +1,104 @@
 # AGENTS.md -- PySafeguard
 
 Python SDK for the One Identity Safeguard Web API. Published on
-[PyPI](https://pypi.org/project/pysafeguard/). Requires Python ≥ 3.10.
+[PyPI](https://pypi.org/project/pysafeguard/). Requires Python >= 3.10.
 
-Dependencies: `requests`, `truststore` (and `typing_extensions` on Python
-< 3.11). Optional extras: `async` (aiohttp), `signalr` (signalrcore).
+Core deps: `requests`, `truststore`, and `typing_extensions` on Python < 3.11.
+Optional extras: `async` (aiohttp) and `signalr` (signalrcore).
 
 ## Project structure
 
 ```
 PySafeguard/
-|-- src/pysafeguard/           # SDK package
-|   |-- __init__.py            # Public API (__all__) and async lazy imports
-|   |-- client.py              # SafeguardClient (sync, requests-based)
-|   |-- async_client.py        # AsyncSafeguardClient (async, aiohttp-based)
-|   |-- auth.py                # Auth protocol + PasswordAuth, CertificateAuth, PkceAuth, TokenAuth
-|   |-- errors.py              # SafeguardError hierarchy
-|   |-- data_types.py          # Enums: Service, HttpMethod, A2AType, SshKeyFormat
-|   |-- event.py               # SafeguardEventListener, PersistentSafeguardEventListener
-|   |-- a2a.py / async_a2a.py  # A2AContext / AsyncA2AContext
-|   |-- hidden_string.py       # HiddenString (sensitive value wrapper)
-|   |-- pkce.py / async_pkce.py # PKCE non-interactive login (internal)
-|   `-- utility.py             # URL assembly, token extraction helpers
-|-- tests/                     # Unit tests (mocked HTTP, no appliance needed)
-|   `-- integration/           # Live-appliance integration tests
-|-- samples/                   # Example scripts for each auth strategy and feature
-|-- pipeline-templates/        # Azure Pipelines shared templates
-|-- pyproject.toml             # Poetry build backend, dependencies, pytest config
-|-- ruff.toml                  # Ruff linter/formatter (line length: 160)
-|-- mypy.ini                   # Mypy strict type checking
-`-- azure-pipelines.yml        # CI/CD: build, lint, test, publish to PyPI on tag
+|-- src/pysafeguard/    # SDK package: clients, auth, errors, A2A, events, HiddenString
+|-- tests/              # Unit tests
+|   `-- integration/    # Live-appliance integration tests
+|-- samples/            # Auth, A2A, and SignalR examples
+|-- pipeline-templates/ # Shared Azure Pipelines templates
+|-- pyproject.toml      # Poetry metadata and pytest config
+|-- ruff.toml           # Ruff config
+|-- mypy.ini            # Mypy config
+`-- azure-pipelines.yml # CI/CD entrypoint
 ```
 
 ## Setup and build
 
 ```bash
-pip install poetry                   # Install Poetry (if needed)
-poetry install --all-extras          # Install all deps including dev and optional
-poetry build                         # Build sdist + wheel
+pip install poetry
+poetry install --all-extras
+poetry build
 ```
 
-All `poetry run` prefixed commands below assume deps are installed via
-`poetry install --all-extras`.
-
-## Linting and type checking
+## Linting
 
 ```bash
-poetry run ruff check src/                   # Lint (line length: 160)
-poetry run ruff format --check src/          # Format check
-poetry run mypy src/                         # Type check (strict mode)
+poetry run ruff check src/
+poetry run ruff format --check src/
+poetry run mypy src/
 ```
 
-All code must pass `mypy --strict` without errors. Ruff enforces 160-char lines.
+All code must pass `mypy --strict`. Ruff enforces 160-character lines.
 
 ## Testing
 
 ```bash
-poetry run python -m pytest tests/ -m "not integration"    # Unit tests
-poetry run python -m pytest tests/ -m integration           # Integration (live appliance)
+poetry run python -m pytest tests/ -m "not integration"
+poetry run python -m pytest tests/ -m integration
 ```
 
-Uses `pytest-asyncio` with `asyncio_mode = "auto"` — async tests run without
-`@pytest.mark.asyncio`. Integration tests auto-skip when `SPP_HOST` is unset.
-
-**For non-trivial auth/API/event changes, ask the user for appliance access.**
-See the `testing-guide` skill for environment variables, fixtures, and patterns.
-
-## Architecture
-
-| Class | Module | Description |
-|---|---|---|
-| `SafeguardClient` | `client.py` | Primary sync client (`requests`) |
-| `AsyncSafeguardClient` | `async_client.py` | Async mirror (`aiohttp`) |
-
-### Auth strategies
-
-Auth objects implement the `Auth` protocol (`auth.py`) and are passed to the
-client constructor. Secret fields are auto-wrapped in `HiddenString`.
-
-| Strategy | Description |
-|---|---|
-| `PasswordAuth` | Username/password (Resource Owner Grant) |
-| `CertificateAuth` | Client certificate authentication |
-| `PkceAuth` | PKCE non-interactive flow (recommended for newer appliances) |
-| `TokenAuth` | Pre-existing bearer token (no refresh) |
-
-### Usage pattern
-
-```python
-from pysafeguard import SafeguardClient, PasswordAuth, Service
-
-with SafeguardClient("appliance.example.com",
-                     auth=PasswordAuth("local", "admin", "secret"),
-                     verify=False) as client:
-    users = client.get(Service.CORE, "Users").json()
-    client.post(Service.CORE, "Users", json={"Name": "NewUser"})
-```
-
-### API services
-
-| Enum | URL path | Description |
-|---|---|---|
-| `Service.CORE` | `service/core` | Users, assets, policies, access requests |
-| `Service.APPLIANCE` | `service/appliance` | Appliance management |
-| `Service.NOTIFICATION` | `service/notification` | Anonymous status endpoints |
-| `Service.A2A` | `service/a2a` | Application-to-Application credentials |
-| `Service.EVENT` | `service/event` | SignalR event streaming |
-| `Service.RSTS` | `RSTS` | Embedded secure token service |
-
-Default API version: **v4**.
-
-### Error hierarchy
-
-```
-SafeguardError
-├── ApiError          (HTTP errors; auto-mapped by status code)
-│   ├── AuthenticationError (401)
-│   ├── AuthorizationError  (403)
-│   └── NotFoundError       (404)
-└── TransportError    (network/connection failures)
-```
+`pytest-asyncio` uses `asyncio_mode = "auto"`. Integration tests auto-skip when
+`SPP_HOST` is unset. For non-trivial auth, API, A2A, or event changes, ask for
+appliance access. See the `testing-guide` skill for fixtures and env vars.
 
 ## Code conventions
 
-- **Type annotations:** Complete on all functions. `mypy --strict` enforced.
-  Use `typing.cast()` for JSON narrowing. `StrEnum` shim in `data_types.py`
-  for Python 3.10; `LiteralString` from `typing_extensions` on < 3.11.
-- **Naming:** Classes PascalCase, methods/attrs snake_case, enums
-  UPPER_CASE values, private attrs `_prefixed`.
-- **Docstrings:** reStructuredText style (`:param name:`, `:returns:`).
-- **Design principles:**
-  1. Side-effect-free constructors — no network I/O in `__init__`
-  2. Auth as strategy objects — not factory functions
-  3. Keyword-only args — after the first 1-2 positional params
-  4. No mutable defaults — use `None` everywhere
-  5. Explicit `json`/`data` split — no magic body inference
-  6. Clean `__all__` — typed, intentional public surface
-  7. Secret protection — `HiddenString` on all credential fields
+- Keep type annotations complete and `mypy --strict` clean.
+- Use PascalCase for classes and snake_case for methods and attributes.
+- Use reStructuredText docstrings.
+- Keep constructors side-effect free.
+- Use auth strategy objects, keyword-only args after the first positional
+  parameters, no mutable defaults, explicit `json` / `data`, intentional
+  `__all__`, and `HiddenString` for secrets.
 
-## Deprecations (v8.0)
+## CI/CD
 
-- **Plural enum aliases:** `Services` → `Service`, `HttpMethods` → `HttpMethod`,
-  `A2ATypes` → `A2AType`, `SshKeyFormats` → `SshKeyFormat`.
-- **`HiddenString.get_value()`** → Use `.value` property instead.
+See the `build-and-release` skill for pipeline details, version derivation,
+and publishing workflow.
 
-## Versioning and release
+## Security
 
-Version is in `pyproject.toml` but **do not edit manually** — CI stamps from
-Git tag via `versionnumber.ps1`. Releases publish to PyPI automatically when a
-tag is pushed (`twine` via `pypiOneIdentity` service connection).
+- Never commit passwords, tokens, A2A API keys, private keys, generated test
+  certs, `.pypirc`, or service-connection output.
+- Wrap new secret-bearing fields in `HiddenString` immediately so `repr()` and
+  `str()` stay redacted.
+- Use `HiddenString.value` only where plaintext is required; avoid logging it
+  and treat `get_value()` as deprecated compatibility.
+- Prefer CA bundle verification over `verify=False`; use
+  `REQUESTS_CA_BUNDLE` / `WEBSOCKET_CLIENT_CA_BUNDLE` when needed.
+
+## Versioning
+
+`pyproject.toml` holds the base semantic version. CI stamps tagged releases and
+`.devN` prereleases via `versionnumber.ps1`; details live in the
+`build-and-release` skill.
 
 ## On-demand skills
 
-The following skills provide deeper reference material. Read the `SKILL.md`
-when your current task matches the trigger.
-
 | Skill | When to read | File |
 |-------|-------------|------|
-| Testing Guide | Running/writing tests, test failures, live appliance setup | `.agents/skills/testing-guide/SKILL.md` |
-| API Patterns | HTTP methods, streaming, errors, A2A, token lifecycle | `.agents/skills/api-patterns/SKILL.md` |
-| Architecture | Module internals, auth flow, events, PKCE, HiddenString | `.agents/skills/architecture/SKILL.md` |
+| Testing Guide | Tests, fixtures, live appliance setup | `.agents/skills/testing-guide/SKILL.md` |
+| API Patterns | HTTP methods, streaming, errors, token lifecycle | `.agents/skills/api-patterns/SKILL.md` |
+| Architecture | Module internals, PKCE, HiddenString, SignalR internals | `.agents/skills/architecture/SKILL.md` |
+| Build and Release | Azure Pipelines, tags, releases, PyPI publish | `.agents/skills/build-and-release/SKILL.md` |
+| A2A Workflow | Certificate registration, API keys, A2A retrieval, brokering, listeners | `.agents/skills/a2a-workflow/SKILL.md` |
+
+## Deprecations (v8.0)
+
+- `Services` -> `Service`, `HttpMethods` -> `HttpMethod`, `A2ATypes` -> `A2AType`, `SshKeyFormats` -> `SshKeyFormat`
+- `HiddenString.get_value()` -> use `.value`
+
+## Keeping this file current
+
+When a change affects setup, linting, testing, security, versioning, pipeline
+behavior, or skill routing, update this file and the relevant
+`.agents/skills/*/SKILL.md` in the same change.


### PR DESCRIPTION
Implements the skills harmonization plan:

- Created `build-and-release` skill (extracted CI/CD from AGENTS.md)
- Created `a2a-workflow` skill (A2AContext, credential retrieval, events)
- Updated AGENTS.md to standard template (section ordering, security, skill routing table)
- Normalized existing skill frontmatter

Part of cross-repo effort to standardize agent skills across all Safeguard SDK repositories.