### PR TITLE
Add Device Code (RFC 8628) authentication

### DIFF
--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -98,6 +98,28 @@ TokenAuth(token: str | HiddenString)
 - `refresh()` always raises `SafeguardError`
 - Token auto-wrapped in `HiddenString`
 
+### DeviceCodeAuth
+
+```python
+DeviceCodeAuth(
+    on_device_code: Callable[[DeviceCodeInfo], None],
+    *,
+    scope: str | None = None,
+    client_id: str = "",
+    polling_interval: int = 5,
+    is_cancelled: Callable[[], bool] | None = None,
+)
+```
+
+- Headless OAuth 2.0 Device Authorization Grant (RFC 8628); the **only**
+  user-interactive login. Never opens a browser or performs display I/O.
+- Hands a `DeviceCodeInfo` (display fields only) to the required
+  `on_device_code` callback, then polls rSTS until approval or expiry.
+- Flow functions live in `device_code.py` (sync) and `async_device_code.py`
+  (async); the async flow awaits the callback result if it is awaitable.
+- Stores no secret — **no `HiddenString` fields and no `dispose()`**.
+- `can_refresh = False`; `refresh()` / `async_refresh()` raise like `TokenAuth`.
+
 ## Adding a New Auth Strategy
 
 1. **Implement the `Auth` protocol** in `auth.py`:

--- a/.agents/skills/testing-guide/SKILL.md
+++ b/.agents/skills/testing-guide/SKILL.md
@@ -103,6 +103,7 @@ not set.
 | `SPP_USERNAME` | No | `Admin` | Safeguard user for authentication. |
 | `SPP_PASSWORD` | **Yes** | — | Password for the Safeguard user. |
 | `SPP_CA_FILE` | No | — | Path to CA certificate file. Omit to disable TLS verification. |
+| `SPP_DEVICE_CODE_INTERACTIVE` | No | — | Set to `1` to run the human-approval Device Code login test. Requires `SPP_HOST`; the test stays skipped otherwise. |
 
 ### Auto-skip Mechanism
 

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,13 @@
+name: "PySafeguard CodeQL config"
+
+# PySafeguard exposes a `verify` parameter (default True) so callers can connect
+# to Safeguard appliances that do not yet have a CA-signed certificate installed
+# (e.g. brand-new or self-signed test appliances). When a caller explicitly opts
+# in with `verify=False`, the SDK disables TLS certificate validation by design.
+# This is an intentional, documented, caller-controlled capability used across the
+# whole SDK (auth.py, async_pkce.py, async_client.py, async_device_code.py), so the
+# `py/request-without-cert-validation` query is treated as a known, accepted pattern
+# and excluded from code scanning for this repository.
+query-filters:
+  - exclude:
+      id: py/request-without-cert-validation

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,7 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,11 @@ poetry run python -m pytest tests/ -m integration
 ```
 
 `pytest-asyncio` uses `asyncio_mode = "auto"`. Integration tests auto-skip when
-`SPP_HOST` is unset. For non-trivial auth, API, A2A, or event changes, ask for
-appliance access. See the `testing-guide` skill for fixtures and env vars.
+`SPP_HOST` is unset. The Device Code interactive integration test additionally
+requires `SPP_DEVICE_CODE_INTERACTIVE=1` (it waits for a human to approve the
+login in a browser) and stays skipped otherwise. For non-trivial auth, API, A2A,
+or event changes, ask for appliance access. See the `testing-guide` skill for
+fixtures and env vars.
 
 ## Code conventions
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,62 @@ with SafeguardClient("safeguard.sample.corp",
     me = client.get(Service.CORE, "Me").json()
 ```
 
+### Device Code Authentication
+
+`DeviceCodeAuth` performs an OAuth 2.0 Device Authorization Grant (RFC 8628)
+login. It is designed for **headless / browser-less** scenarios: the SDK
+requests a device code from the appliance and hands the verification URL and
+user code to a **required** callback. Your code displays that information; the
+user authenticates in their own browser on any device; and the SDK polls until
+the login is approved or the code expires.
+
+The library never prints anything and never opens a browser — displaying the
+`DeviceCodeInfo` is entirely the caller's responsibility.
+
+> **Prerequisite:** The appliance must allow the Device Code grant. Enable it
+> under **Settings → OAuth 2.0 Grant Types / API Settings** by adding
+> `DeviceCode` to the `Allowed OAuth2 Grant Types` setting. When the grant is
+> disabled, login fails with a clear error:
+> `OAuth2 device code grant type is not allowed.`
+
+```Python
+from pysafeguard import SafeguardClient, DeviceCodeAuth, DeviceCodeInfo, Service
+
+def show_device_code(info: DeviceCodeInfo) -> None:
+    # Displaying the URL and code is the caller's responsibility.
+    print(f"Open {info.verification_uri_complete} to sign in")
+    print(f"  Verification URL: {info.verification_uri}")
+    print(f"  User code:        {info.user_code}")
+
+with SafeguardClient("safeguard.sample.corp",
+                     auth=DeviceCodeAuth(show_device_code),
+                     verify="ssl/pathtoca.pem") as client:
+    me = client.get(Service.CORE, "Me").json()
+    print(f"Connected to Safeguard as {me['DisplayName']}")
+```
+
+For async clients the callback may be a coroutine function; its awaitable
+result is awaited. Sync callbacks must be plain functions.
+
+```Python
+from pysafeguard import AsyncSafeguardClient, DeviceCodeAuth, DeviceCodeInfo, Service
+
+async def show_device_code(info: DeviceCodeInfo) -> None:
+    print(f"Open {info.verification_uri_complete} and enter {info.user_code}")
+
+async with AsyncSafeguardClient("safeguard.sample.corp",
+                                auth=DeviceCodeAuth(show_device_code),
+                                verify="ssl/pathtoca.pem") as client:
+    resp = await client.get(Service.CORE, "Me")
+    me = await resp.json()
+```
+
+`DeviceCodeAuth` is interactive and stores no secret, so it cannot refresh
+(`can_refresh` is `False`); obtain a new login when the token expires. Optional
+keyword-only arguments include `scope`, `client_id`, `polling_interval` (auto-
+bumps when the appliance asks the client to slow down), and an `is_cancelled`
+hook for aborting the wait.
+
 ### Async Usage
 
 PySafeguard provides full async support via `AsyncSafeguardClient`:
@@ -524,6 +580,7 @@ from pysafeguard import (
     PasswordAuth,
     CertificateAuth,
     PkceAuth,
+    DeviceCodeAuth,
     TokenAuth,
     Service,
     HttpMethod,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "pysafeguard"
 description = "One Identity Safeguard Python Package"
-version = "8.0.5"
+version = "8.1.0"
 readme = { file = "README.md", content-type = "text/markdown" }
 keywords = ["safeguard", "oneidentity"]
 license = "Apache"

--- a/samples/DeviceCodeExample.py
+++ b/samples/DeviceCodeExample.py
@@ -1,0 +1,33 @@
+# Copyright (c) One Identity LLC. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+import json
+
+from pysafeguard import DeviceCodeAuth, DeviceCodeInfo, SafeguardClient, Service
+
+# The appliance host name or IP address
+host = ""
+
+# Path to the trusted root CA of the appliance
+ca_file = ""
+
+
+def show_device_code(info: DeviceCodeInfo) -> None:
+    # Displaying the verification URL and user code is the caller's
+    # responsibility. The SDK never prints anything or opens a browser.
+    print("To sign in, use a web browser on any device to open the page below")
+    print(f"  {info.verification_uri_complete}")
+    print("If the code is not pre-filled, enter it manually:")
+    print(f"  Verification URL: {info.verification_uri}")
+    print(f"  User code:        {info.user_code}")
+    print(f"Waiting for you to authenticate (expires in {info.expires_in} seconds)...")
+
+
+with SafeguardClient(host, auth=DeviceCodeAuth(show_device_code), verify=ca_file) as client:
+    print("Getting me")
+    result = client.get(Service.CORE, "Me")
+    print(json.dumps(result.json(), indent=2, sort_keys=True))
+
+    print("Getting login time remaining")
+    minutes_left = client.token_lifetime_remaining
+    print(f"Time remaining: {minutes_left}")

--- a/src/pysafeguard/__init__.py
+++ b/src/pysafeguard/__init__.py
@@ -13,6 +13,7 @@ from .client import SafeguardClient as SafeguardClient
 # Auth strategies
 from .auth import Auth as Auth
 from .auth import CertificateAuth as CertificateAuth
+from .auth import DeviceCodeAuth as DeviceCodeAuth
 from .auth import PasswordAuth as PasswordAuth
 from .auth import PkceAuth as PkceAuth
 from .auth import TokenAuth as TokenAuth
@@ -43,6 +44,7 @@ from .event import SafeguardEventListener as SafeguardEventListener
 from .event import SafeguardStateCallback as SafeguardStateCallback
 
 # Types
+from .data_types import DeviceCodeInfo as DeviceCodeInfo
 from .hidden_string import HiddenString as HiddenString
 
 if TYPE_CHECKING:
@@ -89,6 +91,7 @@ __all__ = [
     "CertificateAuth",
     "TokenAuth",
     "PkceAuth",
+    "DeviceCodeAuth",
     # Errors
     "SafeguardError",
     "ApiError",
@@ -113,4 +116,5 @@ __all__ = [
     "SafeguardStateCallback",
     # Types
     "HiddenString",
+    "DeviceCodeInfo",
 ]

--- a/src/pysafeguard/async_device_code.py
+++ b/src/pysafeguard/async_device_code.py
@@ -16,7 +16,6 @@ flow still requires a plain function.
 from __future__ import annotations
 
 import asyncio
-import inspect
 import ssl
 import time
 from collections.abc import Awaitable, Callable
@@ -78,7 +77,7 @@ async def async_get_device_code_token(
         info = DeviceCodeInfo.from_device_login(device_login, default_interval=polling_interval)
 
         result = on_device_code(info)
-        if inspect.isawaitable(result):
+        if isinstance(result, Awaitable):
             await result
 
         rsts_access_token = await _async_poll_for_token(

--- a/src/pysafeguard/async_device_code.py
+++ b/src/pysafeguard/async_device_code.py
@@ -1,0 +1,179 @@
+# Copyright (c) One Identity LLC. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Async Device Authorization Grant login for Safeguard.
+
+Async mirror of :mod:`pysafeguard.device_code` using ``aiohttp`` instead of
+``requests``. Reuses the shared constants and validators from the sync module
+the way :mod:`pysafeguard.async_pkce` reuses :mod:`pysafeguard.pkce`.
+
+In addition to the optional ``is_cancelled`` hook, this implementation honors
+``asyncio`` cancellation: :class:`asyncio.CancelledError` is never caught or
+suppressed. If ``on_device_code`` returns an awaitable it is awaited; the sync
+flow still requires a plain function.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import ssl
+import time
+from collections.abc import Awaitable, Callable
+
+from aiohttp import ClientSession, ClientTimeout
+
+from .data_types import DeviceCodeInfo
+from .device_code import (
+    DEFAULT_DEVICE_CODE_SCOPE,
+    DEVICE_CODE_GRANT_TYPE,
+    _SLOW_DOWN_INCREMENT,
+    _extract_device_code,
+    _interpret_poll_result,
+    _raise_for_disabled_grant,
+)
+from .errors import SafeguardError
+from .pkce import DEFAULT_TIMEOUT
+from .async_pkce import _async_post_login_response, _create_ssl_context
+
+
+async def async_get_device_code_token(
+    appliance: str,
+    *,
+    on_device_code: Callable[[DeviceCodeInfo], None | Awaitable[None]],
+    scope: str | None = None,
+    client_id: str = "",
+    polling_interval: int = 5,
+    is_cancelled: Callable[[], bool] | None = None,
+    verify: bool | str = True,
+    api_version: str = "v4",
+) -> str:
+    """Async Device Authorization Grant flow returning a Safeguard user token.
+
+    :param appliance: Network address (hostname or IP) of the Safeguard appliance.
+    :param on_device_code: Required callback invoked exactly once with a
+        :class:`~pysafeguard.data_types.DeviceCodeInfo`. It may be a plain function
+        or a coroutine function; if it returns an awaitable the result is awaited.
+        The library prints nothing and never opens a browser.
+    :param scope: rSTS scope; defaults to ``rsts:sts:primaryproviderid:local``.
+    :param client_id: OAuth client id; defaults to ``""`` like the other SDKs.
+    :param polling_interval: Seconds between poll attempts; auto-bumps on ``slow_down``.
+    :param is_cancelled: Optional callback; when it returns truthy the login aborts.
+    :param verify: A path to a CA certificate file, or ``False`` to disable TLS verification.
+    :param api_version: API version to use (default ``"v4"``).
+    :returns: A Safeguard user token string.
+    :raises SafeguardError: If the grant is disabled, the user denies or never
+        completes authentication, the code expires, or the login is cancelled.
+    """
+    if polling_interval <= 0:
+        raise SafeguardError("polling_interval must be a positive number of seconds.")
+
+    resolved_scope = scope if scope is not None else DEFAULT_DEVICE_CODE_SCOPE
+    ssl_context = _create_ssl_context(verify)
+    timeout = ClientTimeout(total=DEFAULT_TIMEOUT)
+
+    async with ClientSession() as session:
+        device_login = await _async_request_device_code(session, appliance, client_id, resolved_scope, ssl_context, timeout)
+        device_code = _extract_device_code(device_login)
+        info = DeviceCodeInfo.from_device_login(device_login, default_interval=polling_interval)
+
+        result = on_device_code(info)
+        if inspect.isawaitable(result):
+            await result
+
+        rsts_access_token = await _async_poll_for_token(
+            session,
+            appliance,
+            device_code,
+            client_id,
+            expires_in=info.expires_in,
+            polling_interval=polling_interval,
+            is_cancelled=is_cancelled,
+            ssl_context=ssl_context,
+            timeout=timeout,
+        )
+
+        return await _async_post_login_response(session, appliance, rsts_access_token, api_version, ssl_context, timeout)
+
+
+async def _async_request_device_code(
+    session: ClientSession,
+    appliance: str,
+    client_id: str,
+    scope: str,
+    ssl_context: ssl.SSLContext | bool,
+    timeout: ClientTimeout,
+) -> dict[str, object]:
+    """Request a device code from rSTS (async), detecting the disabled-grant condition."""
+    url = f"https://{appliance}/RSTS/oauth2/DeviceLogin"
+    body = {"client_id": client_id, "scope": scope}
+
+    async with session.post(url, json=body, headers={"Accept": "application/json"}, ssl=ssl_context, timeout=timeout) as resp:
+        status = resp.status
+        if not (200 <= status < 300):
+            text = await resp.text()
+            # Disabled-grant responses are HTML, not JSON — substring match only.
+            _raise_for_disabled_grant(text, status)
+            raise SafeguardError(
+                f"Failed to start device code login: {status} {text}",
+                status_code=status,
+                response_body=text,
+            )
+        data: object = await resp.json(content_type=None)
+
+    if not isinstance(data, dict):
+        raise SafeguardError("Unexpected response from RSTS DeviceLogin endpoint")
+    return data
+
+
+async def _async_poll_for_token(
+    session: ClientSession,
+    appliance: str,
+    device_code: str,
+    client_id: str,
+    *,
+    expires_in: int,
+    polling_interval: int,
+    is_cancelled: Callable[[], bool] | None,
+    ssl_context: ssl.SSLContext | bool,
+    timeout: ClientTimeout,
+) -> str:
+    """Poll the rSTS token endpoint until success, denial, expiry, or deadline (async)."""
+    url = f"https://{appliance}/RSTS/oauth2/token"
+    body = {
+        "grant_type": DEVICE_CODE_GRANT_TYPE,
+        "device_code": device_code,
+        "client_id": client_id,
+    }
+
+    # Fixed deadline from the appliance's expires_in; never extended.
+    deadline = time.monotonic() + expires_in
+    interval = polling_interval
+
+    while True:
+        _check_cancelled(is_cancelled)
+        if time.monotonic() >= deadline:
+            raise SafeguardError("Device code login timed out before the user completed authentication.")
+
+        async with session.post(url, json=body, headers={"Accept": "application/json"}, ssl=ssl_context, timeout=timeout) as resp:
+            status = resp.status
+            text = await resp.text()
+
+        outcome, access_token = _interpret_poll_result(status, text)
+        if outcome == "success":
+            return access_token
+        if outcome == "slow_down":
+            interval += _SLOW_DOWN_INCREMENT
+
+        _check_cancelled(is_cancelled)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise SafeguardError("Device code login timed out before the user completed authentication.")
+        # Sleep only up to the remaining deadline so expiry is not overshot.
+        await asyncio.sleep(min(interval, remaining))
+
+
+def _check_cancelled(is_cancelled: Callable[[], bool] | None) -> None:
+    """Raise if the caller-supplied cancel hook reports cancellation."""
+    if is_cancelled is not None and is_cancelled():
+        raise SafeguardError("Device code login was cancelled before completion.")

--- a/src/pysafeguard/auth.py
+++ b/src/pysafeguard/auth.py
@@ -19,7 +19,8 @@ Example::
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from collections.abc import Callable
+from dataclasses import KW_ONLY, dataclass, field
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import requests as _requests
@@ -32,6 +33,7 @@ from .utility import JsonType
 if TYPE_CHECKING:
     from .async_client import AsyncSafeguardClient
     from .client import SafeguardClient
+    from .data_types import DeviceCodeInfo
 
 
 # ---------------------------------------------------------------------------
@@ -402,3 +404,78 @@ class TokenAuth:
     def dispose(self) -> None:
         """Zero out the stored token."""
         self.token.dispose()
+
+
+@dataclass(frozen=True, eq=False)
+class DeviceCodeAuth:
+    """OAuth 2.0 Device Authorization Grant (RFC 8628) authentication.
+
+    A headless, browser-less interactive login. The SDK requests a device code
+    from the appliance and hands the verification URL and user code to the
+    required ``on_device_code`` callback. Displaying that information is the
+    caller's responsibility — the library never prints or opens a browser. The
+    SDK then polls until the user authenticates (on any device) or the code
+    expires.
+
+    Unlike the other strategies this flow stores no password, token, or device
+    code, so it holds no :class:`~pysafeguard.hidden_string.HiddenString` fields
+    and has no ``dispose()``. It is interactive and cannot silently re-authenticate,
+    so ``can_refresh`` is ``False`` and ``refresh`` raises like :class:`TokenAuth`.
+
+    Example::
+
+        def show(info):
+            print(f"Visit {info.verification_uri_complete} and enter {info.user_code}")
+
+        auth = DeviceCodeAuth(show)
+        client = SafeguardClient("appliance", auth=auth)
+
+    .. note::
+        For async clients ``on_device_code`` may be a coroutine function; its
+        awaitable result is awaited. Sync callbacks must be plain functions.
+    """
+
+    on_device_code: Callable[[DeviceCodeInfo], None]
+    _: KW_ONLY
+    scope: str | None = None
+    client_id: str = ""
+    polling_interval: int = 5
+    is_cancelled: Callable[[], bool] | None = None
+
+    @property
+    def can_refresh(self) -> bool:
+        return False
+
+    def authenticate(self, client: SafeguardClient) -> str:
+        from .device_code import get_device_code_token
+
+        return get_device_code_token(
+            client.host or "",
+            on_device_code=self.on_device_code,
+            scope=self.scope,
+            client_id=self.client_id,
+            polling_interval=self.polling_interval,
+            is_cancelled=self.is_cancelled,
+            verify=client.verify,
+            api_version=client.api_version,
+        )
+
+    def refresh(self, client: SafeguardClient) -> str:
+        raise SafeguardError("DeviceCodeAuth does not support refresh. Device code login is interactive; start a new login.")
+
+    async def async_authenticate(self, client: AsyncSafeguardClient) -> str:
+        from .async_device_code import async_get_device_code_token
+
+        return await async_get_device_code_token(
+            client.host or "",
+            on_device_code=self.on_device_code,
+            scope=self.scope,
+            client_id=self.client_id,
+            polling_interval=self.polling_interval,
+            is_cancelled=self.is_cancelled,
+            verify=client.verify,
+            api_version=client.api_version,
+        )
+
+    async def async_refresh(self, client: AsyncSafeguardClient) -> str:
+        raise SafeguardError("DeviceCodeAuth does not support refresh. Device code login is interactive; start a new login.")

--- a/src/pysafeguard/data_types.py
+++ b/src/pysafeguard/data_types.py
@@ -1,8 +1,11 @@
 # Copyright (c) One Identity LLC. All rights reserved.
 # Licensed under the Apache License, Version 2.0.
 
+from __future__ import annotations
+
 import enum
 import sys
+from dataclasses import dataclass
 
 if sys.version_info < (3, 11):
 
@@ -45,3 +48,71 @@ Services = Service
 HttpMethods = HttpMethod
 A2ATypes = A2AType
 SshKeyFormats = SshKeyFormat
+
+
+@dataclass(frozen=True)
+class DeviceCodeInfo:
+    """Display information for an OAuth 2.0 Device Authorization Grant (RFC 8628).
+
+    An instance is handed to the caller-supplied ``on_device_code`` callback so
+    the caller can present the verification URL and user code to the end user.
+    The library performs no display I/O of its own and never opens a browser.
+
+    The raw ``device_code`` is intentionally **not** exposed here; the SDK keeps
+    it internal and owns the polling loop.
+
+    :ivar user_code: The code the user enters at the verification URL.
+    :ivar verification_uri: The URL the user visits to authorize the device.
+    :ivar verification_uri_complete: The verification URL with the user code
+        pre-filled, suitable for display or QR encoding.
+    :ivar expires_in: Lifetime in seconds of the device code and user code.
+    :ivar interval: Minimum number of seconds to wait between polling requests.
+    """
+
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str
+    expires_in: int
+    interval: int
+
+    @classmethod
+    def from_device_login(cls, data: object, *, default_interval: int) -> DeviceCodeInfo:
+        """Build a :class:`DeviceCodeInfo` from an rSTS ``DeviceLogin`` JSON body.
+
+        :param data: Parsed JSON object returned by ``POST /RSTS/oauth2/DeviceLogin``.
+        :param default_interval: Polling interval used when the response omits ``interval``.
+        :returns: A validated :class:`DeviceCodeInfo` containing only display fields.
+        :raises SafeguardError: If required display fields are missing or malformed.
+        """
+        from .errors import SafeguardError
+
+        if not isinstance(data, dict):
+            raise SafeguardError("Unexpected response from RSTS DeviceLogin endpoint: expected a JSON object")
+
+        user_code = data.get("user_code")
+        if not isinstance(user_code, str) or not user_code:
+            raise SafeguardError("RSTS DeviceLogin response is missing the 'user_code' field")
+
+        verification_uri = data.get("verification_uri")
+        if not isinstance(verification_uri, str) or not verification_uri:
+            raise SafeguardError("RSTS DeviceLogin response is missing the 'verification_uri' field")
+
+        verification_uri_complete = data.get("verification_uri_complete")
+        if not isinstance(verification_uri_complete, str) or not verification_uri_complete:
+            raise SafeguardError("RSTS DeviceLogin response is missing the 'verification_uri_complete' field")
+
+        expires_in = data.get("expires_in")
+        if not isinstance(expires_in, int) or isinstance(expires_in, bool):
+            raise SafeguardError("RSTS DeviceLogin response is missing an integer 'expires_in' field")
+
+        interval = data.get("interval", default_interval)
+        if not isinstance(interval, int) or isinstance(interval, bool):
+            raise SafeguardError("RSTS DeviceLogin response contains a non-integer 'interval' field")
+
+        return cls(
+            user_code=user_code,
+            verification_uri=verification_uri,
+            verification_uri_complete=verification_uri_complete,
+            expires_in=expires_in,
+            interval=interval,
+        )

--- a/src/pysafeguard/device_code.py
+++ b/src/pysafeguard/device_code.py
@@ -1,0 +1,247 @@
+# Copyright (c) One Identity LLC. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Device Authorization Grant login for Safeguard.
+
+Implements the OAuth 2.0 Device Authorization Grant (RFC 8628) against the
+Safeguard rSTS endpoints. This is a headless, browser-less interactive login:
+the SDK requests a device code, hands the verification URL and user code to a
+caller-supplied callback, then polls until the user authenticates in their own
+browser (on any device) or the code expires.
+
+The library performs **no** display I/O and never opens a browser — presenting
+the :class:`~pysafeguard.data_types.DeviceCodeInfo` is the caller's
+responsibility.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+
+from requests import Session
+
+from .data_types import DeviceCodeInfo
+from .errors import SafeguardError
+from .pkce import DEFAULT_TIMEOUT, _post_login_response
+
+# Default scope matches the other Safeguard SDKs (primary local provider).
+DEFAULT_DEVICE_CODE_SCOPE = "rsts:sts:primaryproviderid:local"
+
+# RFC 8628 device-code grant type used when polling the token endpoint.
+DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+
+# Number of seconds added to the polling interval when the server returns slow_down.
+_SLOW_DOWN_INCREMENT = 5
+
+# Case-insensitive substring the appliance returns (as HTML or JSON) when the
+# Device Code grant type is not enabled.
+_DISABLED_GRANT_MARKER = "device code grant type is not allowed"
+
+_DISABLED_GRANT_MESSAGE = (
+    "OAuth2 device code grant type is not allowed. Enable it on the appliance under "
+    "Settings -> OAuth 2.0 Grant Types / API Settings by adding 'DeviceCode' to the "
+    "'Allowed OAuth2 Grant Types' setting."
+)
+
+
+def get_device_code_token(
+    appliance: str,
+    *,
+    on_device_code: Callable[[DeviceCodeInfo], None],
+    scope: str | None = None,
+    client_id: str = "",
+    polling_interval: int = 5,
+    is_cancelled: Callable[[], bool] | None = None,
+    verify: bool | str = True,
+    api_version: str = "v4",
+) -> str:
+    """Perform the Device Authorization Grant flow and return a Safeguard user token.
+
+    :param appliance: Network address (hostname or IP) of the Safeguard appliance.
+    :param on_device_code: Required callback invoked exactly once with a
+        :class:`~pysafeguard.data_types.DeviceCodeInfo`. The caller decides how to
+        display it; the library prints nothing and never opens a browser.
+    :param scope: rSTS scope; defaults to ``rsts:sts:primaryproviderid:local``.
+    :param client_id: OAuth client id; defaults to ``""`` like the other SDKs.
+    :param polling_interval: Seconds between poll attempts; auto-bumps on ``slow_down``.
+    :param is_cancelled: Optional callback; when it returns truthy the login aborts.
+    :param verify: A path to a CA certificate file, or ``False`` to disable TLS verification.
+    :param api_version: API version to use (default ``"v4"``).
+    :returns: A Safeguard user token string.
+    :raises SafeguardError: If the grant is disabled, the user denies or never
+        completes authentication, the code expires, or the login is cancelled.
+    """
+    if polling_interval <= 0:
+        raise SafeguardError("polling_interval must be a positive number of seconds.")
+
+    resolved_scope = scope if scope is not None else DEFAULT_DEVICE_CODE_SCOPE
+
+    with Session() as session:
+        session.verify = verify
+
+        device_login = _request_device_code(session, appliance, client_id, resolved_scope)
+        device_code = _extract_device_code(device_login)
+        info = DeviceCodeInfo.from_device_login(device_login, default_interval=polling_interval)
+
+        on_device_code(info)
+
+        rsts_access_token = _poll_for_token(
+            session,
+            appliance,
+            device_code,
+            client_id,
+            expires_in=info.expires_in,
+            polling_interval=polling_interval,
+            is_cancelled=is_cancelled,
+        )
+
+        return _post_login_response(session, appliance, rsts_access_token, api_version)
+
+
+def _request_device_code(session: Session, appliance: str, client_id: str, scope: str) -> dict[str, object]:
+    """Request a device code from rSTS, detecting the disabled-grant condition."""
+    url = f"https://{appliance}/RSTS/oauth2/DeviceLogin"
+    body = {"client_id": client_id, "scope": scope}
+
+    resp = session.post(url, json=body, headers={"Accept": "application/json"}, timeout=DEFAULT_TIMEOUT)
+
+    if not resp.ok:
+        # Disabled-grant responses are HTML, not JSON — substring match only.
+        _raise_for_disabled_grant(resp.text, resp.status_code)
+        raise SafeguardError(
+            f"Failed to start device code login: {resp.status_code} {resp.text}",
+            status_code=resp.status_code,
+            response_body=resp.text,
+        )
+
+    data: object = resp.json()
+    if not isinstance(data, dict):
+        raise SafeguardError("Unexpected response from RSTS DeviceLogin endpoint")
+    return data
+
+
+def _poll_for_token(
+    session: Session,
+    appliance: str,
+    device_code: str,
+    client_id: str,
+    *,
+    expires_in: int,
+    polling_interval: int,
+    is_cancelled: Callable[[], bool] | None,
+) -> str:
+    """Poll the rSTS token endpoint until success, denial, expiry, or deadline."""
+    url = f"https://{appliance}/RSTS/oauth2/token"
+    body = {
+        "grant_type": DEVICE_CODE_GRANT_TYPE,
+        "device_code": device_code,
+        "client_id": client_id,
+    }
+
+    # Fixed deadline from the appliance's expires_in; never extended.
+    deadline = time.monotonic() + expires_in
+    interval = polling_interval
+
+    while True:
+        _check_cancelled(is_cancelled)
+        if time.monotonic() >= deadline:
+            raise SafeguardError("Device code login timed out before the user completed authentication.")
+
+        resp = session.post(url, json=body, headers={"Accept": "application/json"}, timeout=DEFAULT_TIMEOUT)
+        outcome, access_token = _interpret_poll_result(resp.status_code, resp.text)
+        if outcome == "success":
+            return access_token
+        if outcome == "slow_down":
+            interval += _SLOW_DOWN_INCREMENT
+
+        _check_cancelled(is_cancelled)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise SafeguardError("Device code login timed out before the user completed authentication.")
+        # Sleep only up to the remaining deadline so expiry is not overshot.
+        time.sleep(min(interval, remaining))
+
+
+def _check_cancelled(is_cancelled: Callable[[], bool] | None) -> None:
+    """Raise if the caller-supplied cancel hook reports cancellation."""
+    if is_cancelled is not None and is_cancelled():
+        raise SafeguardError("Device code login was cancelled before completion.")
+
+
+def _extract_device_code(data: dict[str, object]) -> str:
+    """Pull the internal ``device_code`` out of the DeviceLogin response."""
+    device_code = data.get("device_code")
+    if not isinstance(device_code, str) or not device_code:
+        raise SafeguardError("RSTS DeviceLogin response did not contain a device_code")
+    return device_code
+
+
+def _raise_for_disabled_grant(body: str, status_code: int) -> None:
+    """Raise a clear error if ``body`` indicates the Device Code grant is disabled.
+
+    The disabled-grant response is HTML on the DeviceLogin endpoint, so this uses
+    a case-insensitive substring match and never parses JSON.
+    """
+    if body and _DISABLED_GRANT_MARKER in body.lower():
+        raise SafeguardError(_DISABLED_GRANT_MESSAGE, status_code=status_code, response_body=body)
+
+
+def _parse_poll_error(body: str) -> str:
+    """Extract the RFC 8628 ``error`` code from a JSON token-endpoint error body."""
+    try:
+        data: object = json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    if isinstance(data, dict):
+        error = data.get("error")
+        if isinstance(error, str):
+            return error
+    return ""
+
+
+def _interpret_poll_result(status_code: int, body: str) -> tuple[str, str]:
+    """Interpret an rSTS device-code token poll response.
+
+    :returns: ``(outcome, access_token)`` where ``outcome`` is ``"success"``,
+        ``"authorization_pending"``, or ``"slow_down"``. ``access_token`` is only
+        populated for ``"success"``.
+    :raises SafeguardError: For terminal errors (denied, expired, disabled, or unknown).
+    """
+    if 200 <= status_code < 300:
+        try:
+            data: object = json.loads(body)
+        except (json.JSONDecodeError, TypeError) as ex:
+            raise SafeguardError("Unexpected response from RSTS token endpoint") from ex
+        if not isinstance(data, dict):
+            raise SafeguardError("Unexpected response from RSTS token endpoint")
+        access_token = data.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise SafeguardError("RSTS token response did not contain an access_token")
+        return "success", access_token
+
+    error = _parse_poll_error(body)
+    if error == "authorization_pending":
+        return "authorization_pending", ""
+    if error == "slow_down":
+        return "slow_down", ""
+    if error == "access_denied":
+        raise SafeguardError(
+            "Device code login was denied by the user.",
+            status_code=status_code,
+            response_body=body,
+        )
+    if error == "expired_token":
+        raise SafeguardError(
+            "The device code expired before the user completed authentication.",
+            status_code=status_code,
+            response_body=body,
+        )
+
+    _raise_for_disabled_grant(body, status_code)
+    raise SafeguardError(
+        f"Device code login failed: {error or body}",
+        status_code=status_code,
+        response_body=body,
+    )

--- a/tests/integration/test_device_code_auth.py
+++ b/tests/integration/test_device_code_auth.py
@@ -1,0 +1,192 @@
+# Copyright (c) One Identity LLC. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Integration tests: Device Authorization Grant (RFC 8628) login (sync + async).
+
+These tests require a live appliance and are auto-skipped when ``SPP_HOST`` is
+unset. They follow the guaranteed end-to-end floor established by
+SafeguardDotNet's ``Suite-DeviceCodeAuthentication``:
+
+1. Save the appliance's ``Allowed OAuth2 Grant Types`` setting.
+2. With the Device Code grant **disabled**, assert the clear disabled-grant error.
+3. With the Device Code grant **enabled**, assert the verification URL is
+   delivered to the required callback.
+4. Restore the original setting.
+
+Scripted no-human approval (LOCAL provider / NO MFA) is opt-in and may be
+skipped if brittle. A human-in-the-loop fallback runs only when both
+``SPP_HOST`` and ``SPP_DEVICE_CODE_INTERACTIVE=1`` are set.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+
+from pysafeguard import (
+    AsyncSafeguardClient,
+    DeviceCodeAuth,
+    DeviceCodeInfo,
+    PkceAuth,
+    SafeguardClient,
+    Service,
+)
+from pysafeguard.async_device_code import async_get_device_code_token
+from pysafeguard.device_code import get_device_code_token
+from pysafeguard.errors import SafeguardError
+
+pytestmark = pytest.mark.integration
+
+_GRANT_SETTING = "Allowed OAuth2 Grant Types"
+_DEVICE_CODE_GRANT = "DeviceCode"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_grant_value(client: SafeguardClient) -> str:
+    for setting in client.get(Service.CORE, "Settings").json():
+        if setting.get("Name") == _GRANT_SETTING:
+            return str(setting.get("Value", ""))
+    raise AssertionError(f"Could not find '{_GRANT_SETTING}' in appliance settings")
+
+
+def _set_grant_value(client: SafeguardClient, value: str) -> None:
+    client.put(Service.CORE, f"Settings/{_GRANT_SETTING}", json={"Value": value})
+
+
+def _with_device_code(value: str, *, enabled: bool) -> str:
+    grants = [g.strip() for g in value.split(",") if g.strip()]
+    present = any(g.lower() == _DEVICE_CODE_GRANT.lower() for g in grants)
+    if enabled and not present:
+        grants.append(_DEVICE_CODE_GRANT)
+    elif not enabled and present:
+        grants = [g for g in grants if g.lower() != _DEVICE_CODE_GRANT.lower()]
+    return ", ".join(grants)
+
+
+@contextmanager
+def _device_code_grant(client: SafeguardClient, *, enabled: bool) -> Iterator[None]:
+    """Toggle the Device Code grant on the appliance and restore it afterward."""
+    original = _get_grant_value(client)
+    try:
+        _set_grant_value(client, _with_device_code(original, enabled=enabled))
+        yield
+    finally:
+        _set_grant_value(client, original)
+
+
+@pytest.fixture()
+def admin_client(spp_host: str, spp_username: str, spp_password: str, spp_verify: bool | str) -> Iterator[SafeguardClient]:
+    """Authenticated client (PKCE, no ROG dependency) for toggling settings."""
+    client = SafeguardClient(spp_host, auth=PkceAuth("local", spp_username, spp_password), verify=spp_verify)
+    client.login()
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+class _CancelAfterDisplay:
+    """Captures the device-code display info, then cancels the poll loop."""
+
+    def __init__(self) -> None:
+        self.info: DeviceCodeInfo | None = None
+
+    def on_device_code(self, info: DeviceCodeInfo) -> None:
+        self.info = info
+
+    def is_cancelled(self) -> bool:
+        # Cancel as soon as the verification URL has been delivered.
+        return self.info is not None
+
+
+# ===========================================================================
+# Guaranteed floor
+# ===========================================================================
+
+
+class TestDeviceCodeDisabledGrant:
+    def test_disabled_grant_reports_clear_error(self, admin_client: SafeguardClient, spp_host: str, spp_verify: bool | str) -> None:
+        with _device_code_grant(admin_client, enabled=False):
+            collector = _CancelAfterDisplay()
+            with pytest.raises(SafeguardError, match="not allowed"):
+                get_device_code_token(
+                    spp_host,
+                    on_device_code=collector.on_device_code,
+                    verify=spp_verify,
+                )
+            assert collector.info is None
+
+
+class TestDeviceCodeEnabledGrant:
+    def test_enabled_grant_delivers_verification_url(self, admin_client: SafeguardClient, spp_host: str, spp_verify: bool | str) -> None:
+        with _device_code_grant(admin_client, enabled=True):
+            collector = _CancelAfterDisplay()
+            # The login is cancelled right after the URL is delivered, so this
+            # asserts the enabled path produces a verification URL without
+            # requiring a human to approve.
+            with pytest.raises(SafeguardError, match="cancelled"):
+                get_device_code_token(
+                    spp_host,
+                    on_device_code=collector.on_device_code,
+                    is_cancelled=collector.is_cancelled,
+                    verify=spp_verify,
+                )
+            assert collector.info is not None
+            assert collector.info.verification_uri
+            assert collector.info.user_code
+            assert collector.info.expires_in > 0
+
+    async def test_async_enabled_grant_delivers_verification_url(self, admin_client: SafeguardClient, spp_host: str, spp_verify: bool | str) -> None:
+        with _device_code_grant(admin_client, enabled=True):
+            collector = _CancelAfterDisplay()
+            with pytest.raises(SafeguardError, match="cancelled"):
+                await async_get_device_code_token(
+                    spp_host,
+                    on_device_code=collector.on_device_code,
+                    is_cancelled=collector.is_cancelled,
+                    verify=spp_verify,
+                )
+            assert collector.info is not None
+            assert collector.info.verification_uri
+            assert collector.info.user_code
+
+
+# ===========================================================================
+# Interactive fallback (human approves in a browser)
+# ===========================================================================
+
+
+_INTERACTIVE = os.environ.get("SPP_DEVICE_CODE_INTERACTIVE") == "1"
+
+
+@pytest.mark.skipif(not _INTERACTIVE, reason="set SPP_DEVICE_CODE_INTERACTIVE=1 to run the human-approval device code test")
+class TestDeviceCodeInteractive:
+    def test_interactive_login_sync(self, admin_client: SafeguardClient, spp_host: str, spp_verify: bool | str) -> None:
+        def show(info: DeviceCodeInfo) -> None:
+            print("\n[device code] Open this URL in a browser and approve the login:")
+            print(f"  {info.verification_uri_complete}")
+            print(f"  Verification URL: {info.verification_uri}")
+            print(f"  User code:        {info.user_code}\n")
+
+        with _device_code_grant(admin_client, enabled=True):
+            with SafeguardClient(spp_host, auth=DeviceCodeAuth(show), verify=spp_verify) as client:
+                resp = client.get(Service.CORE, "Me")
+                assert resp.status_code == 200
+
+    async def test_interactive_login_async(self, admin_client: SafeguardClient, spp_host: str, spp_verify: bool | str) -> None:
+        def show(info: DeviceCodeInfo) -> None:
+            print("\n[device code] Open this URL in a browser and approve the login:")
+            print(f"  {info.verification_uri_complete}")
+            print(f"  User code: {info.user_code}\n")
+
+        with _device_code_grant(admin_client, enabled=True):
+            async with AsyncSafeguardClient(spp_host, auth=DeviceCodeAuth(show), verify=spp_verify) as client:
+                resp = await client.get(Service.CORE, "Me")
+                assert resp.status == 200

--- a/tests/integration/test_device_code_auth.py
+++ b/tests/integration/test_device_code_auth.py
@@ -84,12 +84,9 @@ def _device_code_grant(client: SafeguardClient, *, enabled: bool) -> Iterator[No
 @pytest.fixture()
 def admin_client(spp_host: str, spp_username: str, spp_password: str, spp_verify: bool | str) -> Iterator[SafeguardClient]:
     """Authenticated client (PKCE, no ROG dependency) for toggling settings."""
-    client = SafeguardClient(spp_host, auth=PkceAuth("local", spp_username, spp_password), verify=spp_verify)
-    client.login()
-    try:
+    with SafeguardClient(spp_host, auth=PkceAuth("local", spp_username, spp_password), verify=spp_verify) as client:
+        client.login()
         yield client
-    finally:
-        client.close()
 
 
 class _CancelAfterDisplay:

--- a/tests/test_device_code.py
+++ b/tests/test_device_code.py
@@ -1,0 +1,554 @@
+# Copyright (c) One Identity LLC. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Tests for the Device Authorization Grant (RFC 8628) login flow.
+
+Covers the sync (:mod:`pysafeguard.device_code`) and async
+(:mod:`pysafeguard.async_device_code`) implementations plus the
+:class:`pysafeguard.auth.DeviceCodeAuth` strategy. No live appliance is
+required — all rSTS HTTP transport is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pysafeguard import DeviceCodeAuth, DeviceCodeInfo
+from pysafeguard.auth import Auth, TokenAuth
+from pysafeguard.errors import SafeguardError
+from pysafeguard.hidden_string import HiddenString
+
+# ---------------------------------------------------------------------------
+# Canonical rSTS payloads
+# ---------------------------------------------------------------------------
+
+_DEVICE_LOGIN_JSON: dict[str, Any] = {
+    "device_code": "secret-device-code",
+    "user_code": "WDJB-MJHT",
+    "verification_uri": "https://appliance/RSTS/DeviceLogin",
+    "verification_uri_complete": "https://appliance/RSTS/DeviceLogin?code=WDJB-MJHT",
+    "expires_in": 300,
+}
+
+_DISABLED_HTML = (
+    "<html><head><title>Error</title></head><body>"
+    "OAuth2 device code grant type is not allowed."
+    "</body></html>"
+)
+
+_LOGIN_RESPONSE_JSON: dict[str, Any] = {"Status": "Success", "UserToken": "the-user-token"}
+
+
+# ---------------------------------------------------------------------------
+# Sync fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    """Minimal stand-in for ``requests.Response``."""
+
+    def __init__(self, status_code: int, *, json_data: Any = None, text: str | None = None, json_raises: bool = False) -> None:
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self._json_data = json_data
+        self._json_raises = json_raises
+        if text is not None:
+            self.text = text
+        elif json_data is not None:
+            self.text = json.dumps(json_data)
+        else:
+            self.text = ""
+
+    def json(self) -> Any:
+        if self._json_raises:
+            raise AssertionError("json() must not be called on this response")
+        if self._json_data is None:
+            raise ValueError("no json body")
+        return self._json_data
+
+
+def _ok_login() -> FakeResponse:
+    return FakeResponse(200, json_data=_LOGIN_RESPONSE_JSON)
+
+
+def _make_sync_session(*, device_login: FakeResponse, poll_responses: list[FakeResponse], login_response: FakeResponse | None = None) -> MagicMock:
+    """Build a fake ``requests.Session`` dispatching by URL."""
+    poll_iter = iter(poll_responses)
+    login = login_response if login_response is not None else _ok_login()
+
+    def post(url: str, **kwargs: Any) -> FakeResponse:
+        if "DeviceLogin" in url:
+            return device_login
+        if "Token/LoginResponse" in url:
+            return login
+        if "oauth2/token" in url:
+            return next(poll_iter)
+        raise AssertionError(f"unexpected url {url}")
+
+    session = MagicMock()
+    session.post.side_effect = post
+    session.__enter__.return_value = session
+    session.__exit__.return_value = False
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Async fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeAsyncResponse:
+    """Async context-manager stand-in for ``aiohttp.ClientResponse``."""
+
+    def __init__(self, status: int, *, json_data: Any = None, text: str | None = None) -> None:
+        self.status = status
+        self._json_data = json_data
+        if text is not None:
+            self._text = text
+        elif json_data is not None:
+            self._text = json.dumps(json_data)
+        else:
+            self._text = ""
+
+    async def text(self) -> str:
+        return self._text
+
+    async def json(self, content_type: Any = None) -> Any:
+        if self._json_data is None:
+            raise ValueError("no json body")
+        return self._json_data
+
+    async def __aenter__(self) -> FakeAsyncResponse:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+class FakeAsyncSession:
+    """Async context-manager stand-in for ``aiohttp.ClientSession``."""
+
+    def __init__(self, *, device_login: FakeAsyncResponse, poll_responses: list[FakeAsyncResponse], login_response: FakeAsyncResponse) -> None:
+        self._device_login = device_login
+        self._poll = iter(poll_responses)
+        self._login = login_response
+
+    def post(self, url: str, **kwargs: Any) -> FakeAsyncResponse:
+        if "DeviceLogin" in url:
+            return self._device_login
+        if "Token/LoginResponse" in url:
+            return self._login
+        if "oauth2/token" in url:
+            return next(self._poll)
+        raise AssertionError(f"unexpected url {url}")
+
+    async def __aenter__(self) -> FakeAsyncSession:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+def _async_device_login(**overrides: Any) -> FakeAsyncResponse:
+    data = {**_DEVICE_LOGIN_JSON, **overrides}
+    return FakeAsyncResponse(200, json_data=data)
+
+
+def _async_ok_login() -> FakeAsyncResponse:
+    return FakeAsyncResponse(200, json_data=_LOGIN_RESPONSE_JSON)
+
+
+# ===========================================================================
+# DeviceCodeInfo
+# ===========================================================================
+
+
+class TestDeviceCodeInfo:
+    def test_from_device_login_defaults_interval(self) -> None:
+        info = DeviceCodeInfo.from_device_login(dict(_DEVICE_LOGIN_JSON), default_interval=7)
+        assert info.user_code == "WDJB-MJHT"
+        assert info.verification_uri == _DEVICE_LOGIN_JSON["verification_uri"]
+        assert info.verification_uri_complete == _DEVICE_LOGIN_JSON["verification_uri_complete"]
+        assert info.expires_in == 300
+        # interval absent in payload -> falls back to default
+        assert info.interval == 7
+
+    def test_from_device_login_uses_response_interval(self) -> None:
+        info = DeviceCodeInfo.from_device_login({**_DEVICE_LOGIN_JSON, "interval": 10}, default_interval=5)
+        assert info.interval == 10
+
+    def test_from_device_login_does_not_expose_device_code(self) -> None:
+        info = DeviceCodeInfo.from_device_login(dict(_DEVICE_LOGIN_JSON), default_interval=5)
+        assert not hasattr(info, "device_code")
+
+    @pytest.mark.parametrize("missing", ["user_code", "verification_uri", "verification_uri_complete"])
+    def test_from_device_login_missing_display_field(self, missing: str) -> None:
+        payload = dict(_DEVICE_LOGIN_JSON)
+        del payload[missing]
+        with pytest.raises(SafeguardError, match=missing):
+            DeviceCodeInfo.from_device_login(payload, default_interval=5)
+
+    def test_from_device_login_non_integer_expires_in(self) -> None:
+        with pytest.raises(SafeguardError, match="expires_in"):
+            DeviceCodeInfo.from_device_login({**_DEVICE_LOGIN_JSON, "expires_in": "soon"}, default_interval=5)
+
+    def test_from_device_login_non_integer_interval(self) -> None:
+        with pytest.raises(SafeguardError, match="interval"):
+            DeviceCodeInfo.from_device_login({**_DEVICE_LOGIN_JSON, "interval": "fast"}, default_interval=5)
+
+    def test_from_device_login_non_dict(self) -> None:
+        with pytest.raises(SafeguardError):
+            DeviceCodeInfo.from_device_login(["not", "a", "dict"], default_interval=5)
+
+    def test_is_frozen(self) -> None:
+        info = DeviceCodeInfo.from_device_login(dict(_DEVICE_LOGIN_JSON), default_interval=5)
+        with pytest.raises(Exception):
+            info.user_code = "changed"  # type: ignore[misc]
+
+
+# ===========================================================================
+# Sync flow: get_device_code_token
+# ===========================================================================
+
+
+class TestSyncDeviceCodeFlow:
+    def test_disabled_grant_detected_without_json_parse(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Disabled grant returns HTML; detection must not call resp.json()."""
+        from pysafeguard import device_code as dc
+
+        # json_raises=True asserts the disabled path never parses JSON.
+        device_login = FakeResponse(400, text=_DISABLED_HTML, json_raises=True)
+        session = _make_sync_session(device_login=device_login, poll_responses=[])
+
+        callback = MagicMock()
+        with patch.object(dc, "Session", return_value=session):
+            with pytest.raises(SafeguardError, match="not allowed"):
+                dc.get_device_code_token("appliance", on_device_code=callback)
+
+        callback.assert_not_called()
+        # The library performs no display I/O.
+        assert capsys.readouterr().out == ""
+
+    def test_callback_invoked_once_and_no_library_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from pysafeguard import device_code as dc
+
+        device_login = FakeResponse(200, json_data=dict(_DEVICE_LOGIN_JSON))
+        success = FakeResponse(200, json_data={"access_token": "rsts-token"})
+        session = _make_sync_session(device_login=device_login, poll_responses=[success])
+
+        received: list[DeviceCodeInfo] = []
+        with patch.object(dc, "Session", return_value=session):
+            with patch.object(dc.time, "sleep"):
+                token = dc.get_device_code_token("appliance", on_device_code=received.append)
+
+        assert token == "the-user-token"
+        assert len(received) == 1
+        assert isinstance(received[0], DeviceCodeInfo)
+        assert received[0].user_code == "WDJB-MJHT"
+        # The callback (test code) printed nothing, and neither did the library.
+        assert capsys.readouterr().out == ""
+
+    def test_poll_transitions_pending_slowdown_success(self) -> None:
+        """authorization_pending -> slow_down (interval bump) -> success."""
+        from pysafeguard import device_code as dc
+
+        device_login = FakeResponse(200, json_data=dict(_DEVICE_LOGIN_JSON))
+        poll_responses = [
+            FakeResponse(400, json_data={"error": "authorization_pending"}),
+            FakeResponse(400, json_data={"error": "slow_down"}),
+            FakeResponse(200, json_data={"access_token": "rsts-token"}),
+        ]
+        session = _make_sync_session(device_login=device_login, poll_responses=poll_responses)
+
+        sleeps: list[float] = []
+        with patch.object(dc, "Session", return_value=session):
+            with patch.object(dc.time, "sleep", side_effect=lambda s: sleeps.append(s)):
+                token = dc.get_device_code_token("appliance", on_device_code=lambda i: None, polling_interval=5)
+
+        assert token == "the-user-token"
+        # Two sleeps before success; the second is bumped by 5 after slow_down.
+        assert sleeps == [5, 10]
+
+    def test_access_denied_raises(self) -> None:
+        from pysafeguard import device_code as dc
+
+        device_login = FakeResponse(200, json_data=dict(_DEVICE_LOGIN_JSON))
+        poll_responses = [FakeResponse(400, json_data={"error": "access_denied"})]
+        session = _make_sync_session(device_login=device_login, poll_responses=poll_responses)
+
+        with patch.object(dc, "Session", return_value=session):
+            with patch.object(dc.time, "sleep"):
+                with pytest.raises(SafeguardError, match="denied"):
+                    dc.get_device_code_token("appliance", on_device_code=lambda i: None)
+
+    def test_expired_token_raises(self) -> None:
+        from pysafeguard import device_code as dc
+
+        device_login = FakeResponse(200, json_data=dict(_DEVICE_LOGIN_JSON))
+        poll_responses = [FakeResponse(400, json_data={"error": "expired_token"})]
+        session = _make_sync_session(device_login=device_login, poll_responses=poll_responses)
+
+        with patch.object(dc, "Session", return_value=session):
+            with patch.object(dc.time, "sleep"):
+                with pytest.raises(SafeguardError, match="expired"):
+                    dc.get_device_code_token("appliance", on_device_code=lambda i: None)
+
+    def test_deadline_exceeded_from_expires_in(self) -> None:
+        """A short expires_in deadline aborts the poll loop with a timeout error."""
+        from pysafeguard import device_code as dc
+
+        device_login = FakeResponse(200, json_data={**_DEVICE_LOGIN_JSON, "expires_in": 10})
+        poll_responses = [FakeResponse(400, json_data={"error": "authorization_pending"})]
+        session = _make_sync_session(device_login=device_login, poll_responses=poll_responses)
+
+        # monotonic: deadline=10; loop check(1)<10; remaining=10-2=8; loop check(11)>=10 -> timeout
+        monotonic_values = iter([0, 1, 2, 11])
+        with patch.object(dc, "Session", return_value=session):
+            with patch.object(dc.time, "sleep"):
+                with patch.object(dc.time, "monotonic", side_effect=lambda: next(monotonic_values)):
+                    with pytest.raises(SafeguardError, match="timed out"):
+                        dc.get_device_code_token("appliance", on_device_code=lambda i: None)
+
+    def test_is_cancelled_aborts_before_polling(self) -> None:
+        from pysafeguard import device_code as dc
+
+        device_login = FakeResponse(200, json_data=dict(_DEVICE_LOGIN_JSON))
+        # No poll responses: cancellation must abort before any token POST.
+        session = _make_sync_session(device_login=device_login, poll_responses=[])
+
+        with patch.object(dc, "Session", return_value=session):
+            with patch.object(dc.time, "sleep"):
+                with pytest.raises(SafeguardError, match="cancelled"):
+                    dc.get_device_code_token("appliance", on_device_code=lambda i: None, is_cancelled=lambda: True)
+
+    def test_rsts_token_exchanged_for_user_token(self) -> None:
+        """The rSTS access token is exchanged through Token/LoginResponse."""
+        from pysafeguard import device_code as dc
+
+        device_login = FakeResponse(200, json_data=dict(_DEVICE_LOGIN_JSON))
+        success = FakeResponse(200, json_data={"access_token": "rsts-token"})
+        login_response = FakeResponse(200, json_data={"Status": "Success", "UserToken": "exchanged-user-token"})
+        session = _make_sync_session(device_login=device_login, poll_responses=[success], login_response=login_response)
+
+        with patch.object(dc, "Session", return_value=session):
+            with patch.object(dc.time, "sleep"):
+                token = dc.get_device_code_token("appliance", on_device_code=lambda i: None)
+
+        assert token == "exchanged-user-token"
+        # Verify the device-code grant body was posted to the token endpoint.
+        token_calls = [c for c in session.post.call_args_list if "oauth2/token" in c.args[0]]
+        assert token_calls
+        body = token_calls[0].kwargs["json"]
+        assert body["grant_type"] == dc.DEVICE_CODE_GRANT_TYPE
+        assert body["device_code"] == "secret-device-code"
+
+    def test_non_positive_polling_interval_rejected(self) -> None:
+        from pysafeguard import device_code as dc
+
+        with pytest.raises(SafeguardError, match="polling_interval"):
+            dc.get_device_code_token("appliance", on_device_code=lambda i: None, polling_interval=0)
+
+
+# ===========================================================================
+# Async flow: async_get_device_code_token
+# ===========================================================================
+
+
+class TestAsyncDeviceCodeFlow:
+    async def test_success_with_sync_callback(self) -> None:
+        from pysafeguard import async_device_code as adc
+
+        session = FakeAsyncSession(
+            device_login=_async_device_login(),
+            poll_responses=[FakeAsyncResponse(200, json_data={"access_token": "rsts-token"})],
+            login_response=_async_ok_login(),
+        )
+        received: list[DeviceCodeInfo] = []
+        with patch.object(adc, "ClientSession", return_value=session):
+            with patch.object(adc.asyncio, "sleep", new=AsyncMock()):
+                token = await adc.async_get_device_code_token("appliance", on_device_code=received.append, verify=False)
+
+        assert token == "the-user-token"
+        assert len(received) == 1
+        assert isinstance(received[0], DeviceCodeInfo)
+
+    async def test_awaitable_callback_is_awaited(self) -> None:
+        from pysafeguard import async_device_code as adc
+
+        session = FakeAsyncSession(
+            device_login=_async_device_login(),
+            poll_responses=[FakeAsyncResponse(200, json_data={"access_token": "rsts-token"})],
+            login_response=_async_ok_login(),
+        )
+
+        awaited: list[DeviceCodeInfo] = []
+
+        async def async_callback(info: DeviceCodeInfo) -> None:
+            awaited.append(info)
+
+        with patch.object(adc, "ClientSession", return_value=session):
+            with patch.object(adc.asyncio, "sleep", new=AsyncMock()):
+                token = await adc.async_get_device_code_token("appliance", on_device_code=async_callback, verify=False)
+
+        assert token == "the-user-token"
+        assert len(awaited) == 1
+        assert isinstance(awaited[0], DeviceCodeInfo)
+
+    async def test_poll_transitions_pending_slowdown_success(self) -> None:
+        from pysafeguard import async_device_code as adc
+
+        session = FakeAsyncSession(
+            device_login=_async_device_login(),
+            poll_responses=[
+                FakeAsyncResponse(400, json_data={"error": "authorization_pending"}),
+                FakeAsyncResponse(400, json_data={"error": "slow_down"}),
+                FakeAsyncResponse(200, json_data={"access_token": "rsts-token"}),
+            ],
+            login_response=_async_ok_login(),
+        )
+
+        sleep_mock = AsyncMock()
+        with patch.object(adc, "ClientSession", return_value=session):
+            with patch.object(adc.asyncio, "sleep", new=sleep_mock):
+                token = await adc.async_get_device_code_token("appliance", on_device_code=lambda i: None, polling_interval=5, verify=False)
+
+        assert token == "the-user-token"
+        slept = [call.args[0] for call in sleep_mock.await_args_list]
+        assert slept == [5, 10]
+
+    async def test_disabled_grant_detected(self) -> None:
+        from pysafeguard import async_device_code as adc
+
+        session = FakeAsyncSession(
+            device_login=FakeAsyncResponse(400, text=_DISABLED_HTML),
+            poll_responses=[],
+            login_response=_async_ok_login(),
+        )
+        callback = MagicMock()
+        with patch.object(adc, "ClientSession", return_value=session):
+            with pytest.raises(SafeguardError, match="not allowed"):
+                await adc.async_get_device_code_token("appliance", on_device_code=callback, verify=False)
+        callback.assert_not_called()
+
+    async def test_access_denied_raises(self) -> None:
+        from pysafeguard import async_device_code as adc
+
+        session = FakeAsyncSession(
+            device_login=_async_device_login(),
+            poll_responses=[FakeAsyncResponse(400, json_data={"error": "access_denied"})],
+            login_response=_async_ok_login(),
+        )
+        with patch.object(adc, "ClientSession", return_value=session):
+            with patch.object(adc.asyncio, "sleep", new=AsyncMock()):
+                with pytest.raises(SafeguardError, match="denied"):
+                    await adc.async_get_device_code_token("appliance", on_device_code=lambda i: None, verify=False)
+
+    async def test_is_cancelled_aborts(self) -> None:
+        from pysafeguard import async_device_code as adc
+
+        session = FakeAsyncSession(
+            device_login=_async_device_login(),
+            poll_responses=[],
+            login_response=_async_ok_login(),
+        )
+        with patch.object(adc, "ClientSession", return_value=session):
+            with patch.object(adc.asyncio, "sleep", new=AsyncMock()):
+                with pytest.raises(SafeguardError, match="cancelled"):
+                    await adc.async_get_device_code_token("appliance", on_device_code=lambda i: None, is_cancelled=lambda: True, verify=False)
+
+
+# ===========================================================================
+# DeviceCodeAuth strategy
+# ===========================================================================
+
+
+class TestDeviceCodeAuth:
+    def test_is_auth_protocol(self) -> None:
+        assert isinstance(DeviceCodeAuth(lambda i: None), Auth)
+
+    def test_frozen(self) -> None:
+        auth = DeviceCodeAuth(lambda i: None)
+        with pytest.raises(Exception):
+            auth.scope = "x"  # type: ignore[misc]
+
+    def test_callback_is_required(self) -> None:
+        with pytest.raises(TypeError):
+            DeviceCodeAuth()  # type: ignore[call-arg]
+
+    def test_keyword_only_options(self) -> None:
+        with pytest.raises(TypeError):
+            DeviceCodeAuth(lambda i: None, "local")  # type: ignore[misc]
+
+    def test_can_refresh_is_false(self) -> None:
+        assert DeviceCodeAuth(lambda i: None).can_refresh is False
+
+    def test_no_hidden_string_fields(self) -> None:
+        import dataclasses
+
+        auth = DeviceCodeAuth(lambda i: None, scope="s", client_id="c", polling_interval=9)
+        for f in dataclasses.fields(auth):
+            assert not isinstance(getattr(auth, f.name), HiddenString)
+
+    def test_no_dispose_method(self) -> None:
+        # No stored secret, so unlike the other strategies there is no dispose().
+        assert not hasattr(DeviceCodeAuth(lambda i: None), "dispose")
+
+    def test_refresh_raises_like_token_auth(self) -> None:
+        auth = DeviceCodeAuth(lambda i: None)
+        client = MagicMock()
+        with pytest.raises(SafeguardError):
+            auth.refresh(client)
+        # Same behavior as TokenAuth.
+        assert TokenAuth("t").can_refresh is False
+
+    async def test_async_refresh_raises(self) -> None:
+        auth = DeviceCodeAuth(lambda i: None)
+        client = MagicMock()
+        with pytest.raises(SafeguardError):
+            await auth.async_refresh(client)
+
+    def test_authenticate_delegates_to_flow(self) -> None:
+        from pysafeguard import device_code as dc
+
+        callback = MagicMock()
+        auth = DeviceCodeAuth(callback, scope="custom-scope", client_id="cid", polling_interval=8)
+        client = MagicMock()
+        client.host = "appliance.example.com"
+        client.verify = False
+        client.api_version = "v4"
+
+        with patch.object(dc, "get_device_code_token", return_value="user-token") as mock_flow:
+            result = auth.authenticate(client)
+
+        assert result == "user-token"
+        _, kwargs = mock_flow.call_args
+        assert mock_flow.call_args.args[0] == "appliance.example.com"
+        assert kwargs["on_device_code"] is callback
+        assert kwargs["scope"] == "custom-scope"
+        assert kwargs["client_id"] == "cid"
+        assert kwargs["polling_interval"] == 8
+        assert kwargs["verify"] is False
+        assert kwargs["api_version"] == "v4"
+
+    async def test_async_authenticate_delegates_to_flow(self) -> None:
+        from pysafeguard import async_device_code as adc
+
+        callback = MagicMock()
+        auth = DeviceCodeAuth(callback, scope="custom-scope", client_id="cid")
+        client = MagicMock()
+        client.host = "appliance.example.com"
+        client.verify = False
+        client.api_version = "v4"
+
+        with patch.object(adc, "async_get_device_code_token", new=AsyncMock(return_value="user-token")) as mock_flow:
+            result = await auth.async_authenticate(client)
+
+        assert result == "user-token"
+        _, kwargs = mock_flow.call_args
+        assert kwargs["on_device_code"] is callback
+        assert kwargs["scope"] == "custom-scope"
+        assert kwargs["client_id"] == "cid"


### PR DESCRIPTION
Adds OAuth 2.0 Device Authorization Grant (RFC 8628) login support for both sync and async clients.

**What''s included**
- `DeviceCodeInfo` type and `DeviceCodeAuth` strategy; sync and async device-code login flows.
- Caller-supplied callback for displaying the verification URL and user code — no library display I/O, no browser spawning.
- Public exports, a usage sample, and documentation.

**Tests**
- 36 new device-code unit tests (325 unit total); ruff + mypy --strict clean.
- Live integration suite green (interactive human-approval tests are opt-in via env var and skipped by default).

Version bumped to 8.1.0 (new functionality → minor).